### PR TITLE
Fix maxSeconds error

### DIFF
--- a/lib/timing.js
+++ b/lib/timing.js
@@ -182,7 +182,7 @@ exports.Latency = function(options, callback)
 			return true;
 		}
 		var elapsedSeconds = getElapsed(initialTime) / 1000;
-		if (options.maxSeconds && elapsedSeconds >= maxSeconds)
+		if (options.maxSeconds && elapsedSeconds >= options.maxSeconds)
 		{
 			log.debug('Max seconds reached: %s', totalRequests);
 			return true;


### PR DESCRIPTION
Calling `loadTest({maxSeconds: 1}, function(){})` throws an error
'ReferenceError: maxSeconds is not defined'.
