### PR TITLE
removed unused reference to cloneextend from package.json and loadtest.js

### DIFF
--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -15,7 +15,6 @@ var fs = require('fs');
 var prototypes = require('./prototypes.js');
 var timing = require('./timing.js');
 var websocket = require('./websocket.js');
-var ce = require('cloneextend');
 
 // globals
 var log = new Log('info');

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
 		"testing": "*",
 		"agentkeepalive": "*",
 		"log": "*",
-		"optimist": "~0.6.0",
-		"cloneextend": "0.0.3"
+		"optimist": "~0.6.0"
 	},
 	"keywords" : ["testing", "test", "load test", "load testing", "http", "performance", "black box"],
 	"engines": {


### PR DESCRIPTION
introduced cloneextend for the merging of options and default options, since this is not necessary anymore i removed it.
