### PR TITLE
Tolerate colon in header values

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -41,9 +41,9 @@ function addHeader(rawHeader, headers)
 	{
 		return console.error('Invalid header %s, it should be in the form -H key:value');
 	}
-	var pieces = rawHeader.split(':');
-	var key = pieces[0];
-	var value = pieces[1];
+	var index = rawHeader.indexOf(':');
+	var key = rawHeader.substr(0, index);
+	var value = rawHeader.substr(index + 1);
 	headers.push([key.toLowerCase(), value]);
 }
 
@@ -66,6 +66,10 @@ function testAddHeaders(callback)
 			raw: 'K:v',
 			headers: [['k', 'v']],
 		},
+		{
+			raw: 'k:v:w',
+			headers: [['k', 'v:w']]
+		}
 	];
 	tests.forEach(function(test)
 	{


### PR DESCRIPTION
The current logic for parsing headers breaks if the value contains a colon (e.g. `-H Referer:http://example.com/`). This change splits the header on the first colon only, allowing the value part to include any colons that may be present.
