### PR TITLE
Add feature to generate POST and PUT request bodies dynamically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,42 @@ Send the string as the POST body. E.g.: `-P '{"key": "a9acf03f"}'`
 ### `-p POST-file`
 
 Send the data contained in the given file in the POST body.
-Remember to set `-T` to the correct content-type.
+Remember to set `-T` to the correct content-type.  
+
+If `POST-file` has `.js` extension it will be `require`d. It should be a valid node module and it
+should `export` a single function, which is invoked with an automatically generated request identifier
+to provide the body of each request.
+This is useful if you want to generate request bodies dynamically and vary them for each request.
+
+Example:
+
+    module.exports = function(requestId) {
+      // this object will be serialized to JSON and sent in the body of the request
+      return {
+        key: 'value',
+        requestId: requestId
+      };
+    };
 
 ### `-u PUT-file`
 
 Send the data contained in the given file as a PUT request.
-Remember to set `-T` to the correct content-type.
+Remember to set `-T` to the correct content-type.  
+
+If `PUT-file` has `.js` extension it will be `require`d. It should be a valid node module and it
+should `export` a single function, which is invoked with an automatically generated request identifier
+to provide the body of each request.
+This is useful if you want to generate request bodies dynamically and vary them for each request.
+
+Example:
+
+    module.exports = function(requestId) {
+      // this object will be serialized to JSON and sent in the body of the request
+      return {
+        key: 'value',
+        requestId: requestId
+      };
+    };
 
 #### `-r`
 

--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -9,6 +9,7 @@
 // requires
 var stdio = require('stdio');
 var fs = require('fs');
+var path = require('path');
 var urlLib = require('url');
 var loadTest = require('../lib/loadtest.js');
 var headers = require('../lib/headers.js');
@@ -73,26 +74,35 @@ if(options.rps)
 {
 	options.requestsPerSecond = parseFloat(options.rps);
 }
-var headers = [
-	['host', urlLib.parse(options.url).host],
-	['user-agent', 'loadtest/' + packageJson.version],
-	['accept', '*/*'],
-];
+var defaultHeaders =
+{
+	host: urlLib.parse(options.url).host,
+	'user-agent': 'loadtest/' + packageJson.version,
+	accept: '*/*'
+};
+
 if (options.headers)
 {
-	headers.addHeaders(options.headers, headers);
-	console.log('headers: %s, %j', typeof headers, headers);
+	headers.addHeaders(options.headers, defaultHeaders);
+	console.log('headers: %s, %j', typeof defaultHeaders, defaultHeaders);
 }
-options.headers = headers;
+
+options.headers = defaultHeaders;
 loadTest.loadTest(options);
 
 function readBody(filename, option)
 {
-	if (typeof filename != 'string')
+	if (typeof filename !== 'string')
 	{
 		console.error('Invalid file to open with %s: %s', option, filename);
 		help();
 	}
+
+	if(path.extname(filename) === '.js')
+	{
+		return require(path.resolve(filename));
+	}
+
 	return fs.readFileSync(filename, {encoding: 'utf8'});
 }
 

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -44,7 +44,7 @@ function addHeader(rawHeader, headers)
 	var index = rawHeader.indexOf(':');
 	var key = rawHeader.substr(0, index);
 	var value = rawHeader.substr(index + 1);
-	headers.push([key.toLowerCase(), value]);
+	headers[key.toLowerCase()] = value;
 }
 
 function testAddHeaders(callback)
@@ -52,70 +52,30 @@ function testAddHeaders(callback)
 	var tests = [
 		{
 			raw: 'k:v',
-			headers: [['k', 'v']],
+			headers: { 'k': 'v' }
 		},
 		{
 			raw: ['k:v', 'k:v2'],
-			headers: [['k', 'v'], ['k', 'v2']],
+			headers:  { 'k': 'v2' }
 		},
 		{
 			raw: ['k:v', 'k2:v2'],
-			headers: [['k', 'v'], ['k2', 'v2']],
+			headers: { 'k': 'v', 'k2': 'v2' }
 		},
 		{
 			raw: 'K:v',
-			headers: [['k', 'v']],
+			headers: { 'k': 'v' }
 		},
 		{
 			raw: 'k:v:w',
-			headers: [['k', 'v:w']]
+			headers: { 'k': 'v:w' }
 		}
 	];
 	tests.forEach(function(test)
 	{
-		var headers = [];
+		var headers = {};
 		exports.addHeaders(test.raw, headers);
 		testing.assertEquals(headers, test.headers, 'Wrong headers', callback);
-	});
-	testing.success(callback);
-}
-
-/**
- * Convert a map of headers to an array.
- */
-exports.convert = function(original)
-{
-	if (Array.isArray(original))
-	{
-		return original.slice(0);
-	}
-	var headers = [];
-	for (var key in original)
-	{
-		headers.push([key, original[key]]);
-	}
-	return headers;
-};
-
-/**
- * Check the conversion from map of headers to array.
- */
-function testConvert(callback)
-{
-	var tests = [
-		{
-			original: [['k', 'v']],
-			headers: [['k', 'v']],
-		},
-		{
-			original: {k: 'v', k2: 'v2'},
-			headers: [['k', 'v'], ['k2', 'v2']],
-		},
-	];
-	tests.forEach(function(test)
-	{
-		var result = exports.convert(test.original);
-		testing.assertEquals(result, test.headers, 'Wrong headers', callback);
 	});
 	testing.success(callback);
 }
@@ -125,33 +85,21 @@ function testConvert(callback)
  */
 exports.addUserAgent = function(headers)
 {
-	for (var index in headers)
+	if(!headers['user-agent'])
 	{
-		var header = headers[index];
-		if (!header)
-		{
-			continue;
-		}
-		if (header[0] == 'user-agent')
-		{
-			return;
-		}
+	  headers['user-agent'] = 'node.js loadtest bot';
 	}
-	headers.push(['user-agent', 'node.js loadtest bot']);
 };
 
 function testAddUserAgent(callback)
 {
-	var headers = [
-		['k', 'v'],
-		['q', 'r'],
-	];
+	var headers =  {'k': 'v', 'q': 'r' };
 	exports.addUserAgent(headers);
-	testing.assertEquals(headers.length, 3, 'Did not add user agent', callback);
-	var userAgent = headers[2][1];
+	testing.assertEquals(Object.keys(headers).length, 3, 'Did not add user agent', callback);
+	var userAgent = headers['user-agent'];
 	testing.assert(userAgent.contains('bot'), 'Invalid user agent', callback);
 	exports.addUserAgent(headers);
-	testing.assertEquals(headers.length, 3, 'Should not add user agent', callback);
+	testing.assertEquals(Object.keys(headers).length, 3, 'Should not add user agent', callback);
 	testing.success(callback);
 }
 
@@ -162,7 +110,6 @@ exports.test = function(callback)
 {
 	testing.run([
 		testAddHeaders,
-		testConvert,
 		testAddUserAgent,
 	], callback);
 };

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -38,7 +38,12 @@ function HttpClient(operation, params)
 	// attributes
 	var requestTimer;
 	var options;
-	var message;
+	var generateMessage;
+
+	function identity(arg)
+	{
+		return function() { return arg; };
+	}
 
 	// init
 	init();
@@ -49,7 +54,7 @@ function HttpClient(operation, params)
 	function init()
 	{
 		options = urlLib.parse(params.url);
-		options.headers = [];
+		options.headers = {};
 		if (params.headers)
 		{
 			options.headers = params.headers;
@@ -73,29 +78,33 @@ function HttpClient(operation, params)
 			if (typeof params.body == 'string')
 			{
 				log.debug('Received string body');
-				message = params.body;
+				generateMessage = identity(params.body);
 			}
 			else if (typeof params.body == 'object')
 			{
 				log.debug('Received JSON body');
-				message = JSON.stringify(params.body);
+				generateMessage = identity(params.body);
+			}
+			else if (typeof params.body == 'function')
+			{
+				log.debug('Received function body');
+				generateMessage = params.body;
 			}
 			else
 			{
 				log.error('Unrecognized body: %s', typeof params.body);
 			}
-			options.headers.push(['Content-Length', Buffer.byteLength(message)]);
-			options.headers.push(['Content-Type', params.contentType || 'text/plain']);
+			options.headers['Content-Type'] = params.contentType || 'text/plain';
 		}
 		if (params.cookies)
 		{
 			if (Array.isArray(params.cookies))
 			{
-				options.headers.push(['Cookie', params.cookies.join('; ')]);
+				options.headers['Cookie'] =  params.cookies.join('; ');
 			}
 			else if (typeof params.cookies == 'string')
 			{
-				options.headers.push(['Cookie', params.cookies]);
+				options.headers['Cookie'] = params.cookies;
 			}
 			else
 			{
@@ -152,8 +161,27 @@ function HttpClient(operation, params)
 			process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 		}
 
-		var request = lib.request(options, getConnect(id, requestFinished));
-		if (message)
+		var request, message;
+
+		if (generateMessage)
+		{
+		  message = generateMessage(id);
+
+			if(typeof message === 'object')
+			{
+				message = JSON.stringify(message);
+			}
+
+			options.headers['Content-Length'] = Buffer.byteLength(message);
+		}
+		else
+		{
+		  delete options.headers['Content-Length'];
+		}
+
+		request = lib.request(options, getConnect(id, requestFinished));
+
+		if(message)
 		{
 			request.write(message);
 		}
@@ -277,10 +305,7 @@ exports.loadTest = function(options, callback)
 	{
 		options.quiet = true;
 	}
-	if (options.headers)
-	{
-		options.headers = headers.convert(options.headers);
-	}
+
 	var operation = new Operation(options, constructor, callback);
 	operation.start();
 };


### PR DESCRIPTION
Fixes issue #29

Note that I did quite some changes to how headers are handled. Previously it was arrays of arrays (and I couldn't figure out why), now it is plain objects. Unless I missed something I think it simplifies everything quite a bit in addition to provide easier lookup and replacement for headers.
