### PR TITLE
Added support for client certificate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 
-# test on one node.js version: 0.10
+# test on node.js version: 0.10 and 0.12
 node_js:
   - 0.10
+  - 0.12
 
 # configure notifications (email, IRC, campfire etc)
 # please update this section to your needs!

--- a/README.md
+++ b/README.md
@@ -274,6 +274,14 @@ Show debug messages.
 
 Allow invalid and self-signed certificates over https.
 
+#### `--cert path/to/cert.pem`
+
+Sets the certificate for the http client to use. Must be used with `--key`.
+
+#### `--key path/to/key.pem`
+
+Sets the key for the http client to use. Must be used with `--cert`.
+
 ### Server
 
 loadtest bundles a test server. To run it:

--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -37,6 +37,8 @@ var options = stdio.getopt({
 	quiet: {description: 'Do not log any messages'},
 	debug: {description: 'Show debug messages'},
 	insecure: {description: 'Allow self-signed certificates over https'},
+	key: {args: 1, description: 'The client key to use'},
+	cert: {args: 1, description: 'The client certificate to use'}
 });
 if (options.version)
 {
@@ -81,6 +83,14 @@ if(options.putFile)
 if(options.rps)
 {
 	options.requestsPerSecond = parseFloat(options.rps);
+}
+if(options.key)
+{
+	options.key = fs.readFileSync(options.key);
+}
+if(options.cert)
+{
+	options.cert = fs.readFileSync(options.cert);
 }
 var defaultHeaders =
 {

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -63,6 +63,11 @@ function HttpClient(operation, params)
 		{
 			options.headers = params.headers;
 		}
+		if (params.cert && params.key)
+		{
+			options.cert = params.cert;
+			options.key = params.key;
+		}
 		options.agent = false;
 		if (params.agentKeepAlive)
 		{


### PR DESCRIPTION
Hey @alexfernandez I have added support for using client certificates as I needed this for some load testing that I was doing. I also, told travis to test with the new latest stable release of node. Please let me know if there is anything else you would like to see in this PR.