### PR TITLE
Fix maxKeepAliveTime default value.

### DIFF
--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -80,7 +80,7 @@ function HttpClient(operation, params)
 			options.agent = new KeepAlive({
 				maxSockets: maxSockets,
 				maxKeepAliveRequests: 0, // max requests per keepalive socket, default is 0, no limit
-				maxKeepAliveTime: 3000  // keepalive for 30 seconds
+				maxKeepAliveTime: 30000  // keepalive for 30 seconds
 			});
 		}
 		if (params.method)


### PR DESCRIPTION
Noticed that the maxKeepAliveTime was set to 3 seconds instead of the 30 seconds stated in the comment. 

That's being used later in a setTimeout in the agentkeepalive module so it's milliseconds.