### PR TITLE
Add optional status callback to operation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,15 +577,12 @@ var options = {
     statusCallback: statusCallback
 };
 
-function callback(error, result) {
-    if (error)
-    {
+loadtest.loadTest(options, function(error) {
+    if (error) {
         return console.error('Got an error: %s', error);
     }
     console.log('Tests run successfully');
-}
-
-loadtest.loadTest(options, callback);
+});
 ```
 
 ### Results

--- a/README.md
+++ b/README.md
@@ -580,6 +580,36 @@ An example follows:
         '500': 2
       }
     }
+    
+### Optional status callback
+
+Optionally you can pass an extra `statusCallback` to the `loadTest()` function so that it can be called on every request
+operation completed, this will allow you to know current test results while the test is still running. The results 
+passed to the callback are in the same format as the results passed to the final callback.
+
+Example:
+
+```javascript
+var loadtest = require('loadtest');
+var options = {
+    url: 'http://localhost:8000',
+    maxRequests: 1000,
+};
+
+function finalCallback(error, result) {
+    if (error)
+    {
+        return console.error('Got an error: %s', error);
+    }
+    console.log('Tests run successfully');
+}
+
+function statusCallback(result) {
+    console.log('Current Status: ' + require('util').inspect(result));
+}
+
+loadtest.loadTest(options, finalCallback, statusCallback);
+```
 
 ### Start Test Server
 

--- a/README.md
+++ b/README.md
@@ -556,6 +556,38 @@ will be:
 
 Allow invalid and self-signed certificates over https.
 
+#### `statusCallback`
+
+Allows the execution of an extra `statusCallback` function on every request operation completed, this will allow you 
+to know current test results while the test is still running. The results passed to the callback are in the same format 
+as the results passed to the final callback.
+
+Example:
+
+```javascript
+var loadtest = require('loadtest');
+
+function statusCallback(result) {
+    console.log('Current Status: ' + require('util').inspect(result));
+}
+
+var options = {
+    url: 'http://localhost:8000',
+    maxRequests: 1000,
+    statusCallback: statusCallback
+};
+
+function callback(error, result) {
+    if (error)
+    {
+        return console.error('Got an error: %s', error);
+    }
+    console.log('Tests run successfully');
+}
+
+loadtest.loadTest(options, callback);
+```
+
 ### Results
 
 The results passed to your callback at the end of the load test contains a full set of data, including:
@@ -581,36 +613,6 @@ An example follows:
       }
     }
     
-### Optional status callback
-
-Optionally you can pass an extra `statusCallback` to the `loadTest()` function so that it can be called on every request
-operation completed, this will allow you to know current test results while the test is still running. The results 
-passed to the callback are in the same format as the results passed to the final callback.
-
-Example:
-
-```javascript
-var loadtest = require('loadtest');
-var options = {
-    url: 'http://localhost:8000',
-    maxRequests: 1000,
-};
-
-function finalCallback(error, result) {
-    if (error)
-    {
-        return console.error('Got an error: %s', error);
-    }
-    console.log('Tests run successfully');
-}
-
-function statusCallback(result) {
-    console.log('Current Status: ' + require('util').inspect(result));
-}
-
-loadtest.loadTest(options, finalCallback, statusCallback);
-```
-
 ### Start Test Server
 
 To start the test server use the exported function `startServer()` with a set of options and an optional callback:

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -385,7 +385,7 @@ var Operation = function(options, Constructor, callback)
 		{
 			next();
 		}
-        if (options.statusCallback && typeof options.statusCallback == "function") {
+        if (options.statusCallback) {
             options.statusCallback(self.latency.getResults());
         }
 	};

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -299,7 +299,7 @@ function HttpClient(operation, params)
  * An optional callback will be called if/when the test finishes.
  * In this case the quiet option is enabled.
  */
-exports.loadTest = function(options, callback)
+exports.loadTest = function(options, callback, statusCallback)
 {
 	var constructor;
 	if (!options.url)
@@ -330,14 +330,14 @@ exports.loadTest = function(options, callback)
 		options.quiet = true;
 	}
 
-	var operation = new Operation(options, constructor, callback);
+	var operation = new Operation(options, constructor, callback, statusCallback);
 	operation.start();
 };
 
 /**
  * A load test operation.
  */
-var Operation = function(options, Constructor, callback)
+var Operation = function(options, Constructor, callback, statusCallback)
 {
 	// self-reference
 	var self = this;
@@ -385,6 +385,9 @@ var Operation = function(options, Constructor, callback)
 		{
 			next();
 		}
+        if (statusCallback) {
+            statusCallback(self.latency.getResults());
+        }
 	};
 
 	/**

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -299,7 +299,7 @@ function HttpClient(operation, params)
  * An optional callback will be called if/when the test finishes.
  * In this case the quiet option is enabled.
  */
-exports.loadTest = function(options, callback, statusCallback)
+exports.loadTest = function(options, callback)
 {
 	var constructor;
 	if (!options.url)
@@ -330,14 +330,14 @@ exports.loadTest = function(options, callback, statusCallback)
 		options.quiet = true;
 	}
 
-	var operation = new Operation(options, constructor, callback, statusCallback);
+	var operation = new Operation(options, constructor, callback);
 	operation.start();
 };
 
 /**
  * A load test operation.
  */
-var Operation = function(options, Constructor, callback, statusCallback)
+var Operation = function(options, Constructor, callback)
 {
 	// self-reference
 	var self = this;
@@ -385,8 +385,8 @@ var Operation = function(options, Constructor, callback, statusCallback)
 		{
 			next();
 		}
-        if (statusCallback) {
-            statusCallback(self.latency.getResults());
+        if (options.statusCallback && typeof options.statusCallback == "function") {
+            options.statusCallback(self.latency.getResults());
         }
 	};
 


### PR DESCRIPTION
The current results object will be sent as the argument of the status callback.

The idea behind this is that I'd like to know the current status of the test while it is running.

I don't think it breaks backwards compatibility since it is optional but let me know what do you think.