### PR TITLE
Fix bug #44: -R requestGeneratorModule.js does not work.

### DIFF
--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -105,6 +105,10 @@ if (options.headers)
 	console.log('headers: %s, %j', typeof defaultHeaders, defaultHeaders);
 }
 
+if (options.requestGenerator) {
+    options.requestGenerator = require(options.requestGenerator);
+}
+
 options.headers = defaultHeaders;
 loadTest.loadTest(options);
 


### PR DESCRIPTION
Need "require" the js module path name specified in commandline to make it work.