### PR TITLE
Ensure that the headers are set before request client is initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,12 +248,14 @@ Example request generator module could look like this:
 ```javascript
 module.exports = function(params, options, client, callback) {
   generateMessageAsync(function(message)) {
-    request = client(options, callback);
 
     if (message)
     {
       options.headers['Content-Length'] = message.length;
       options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+    }
+    request = client(options, callback);
+    if (message){
       request.write(message);
     }
 

--- a/lib/request-generator.js
+++ b/lib/request-generator.js
@@ -29,9 +29,9 @@ function testRequestGenerator(callback)
 			requestGenerator: function(params, options, client, callback)
 			{
 				var message = '{"hi": "ho"}';
-				var request = client(options, callback);
 				options.headers['Content-Length'] = message.length;
 				options.headers['Content-Type'] = 'application/json';
+				var request = client(options, callback);
 				request.write(message);
 				request.end();
 			},


### PR DESCRIPTION
Had the problem when using loadTest with authentication that at least one request would fail.
This is due to the fact that the request is initialized before setting the headers.