### PR TITLE
Ensure error handling with requestGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ module.exports = function(params, options, client, callback) {
       request.write(message);
     }
 
-    request.end();
+    return request;
   }
 }
 ```

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -194,8 +194,8 @@ function HttpClient(operation, params)
 		if (typeof params.requestGenerator == 'function') {
 			request = params.requestGenerator(params, options, lib.request, getConnect(id, requestFinished));
 		} else {
-      request = lib.request(options, getConnect(id, requestFinished));
-    }
+			request = lib.request(options, getConnect(id, requestFinished));
+		}
 
 		if (params.hasOwnProperty("timeout")) {
 			request.setTimeout(params.timeout, function() {

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -197,7 +197,7 @@ function HttpClient(operation, params)
       request = lib.request(options, getConnect(id, requestFinished));
     }
 
-		if (params.timeout) {
+		if (params.hasOwnProperty("timeout")) {
 			request.setTimeout(params.timeout, function() {
 				requestFinished('Connection timed out');
 			});

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -192,10 +192,11 @@ function HttpClient(operation, params)
 		}
 
 		if (typeof params.requestGenerator == 'function') {
-			return params.requestGenerator(params, options, lib.request, getConnect(id, requestFinished));
-		}
+			request = params.requestGenerator(params, options, lib.request, getConnect(id, requestFinished));
+		} else {
+      request = lib.request(options, getConnect(id, requestFinished));
+    }
 
-		request = lib.request(options, getConnect(id, requestFinished));
 		if (params.timeout) {
 			request.setTimeout(params.timeout, function() {
 				requestFinished('Connection timed out');

--- a/lib/request-generator.js
+++ b/lib/request-generator.js
@@ -33,7 +33,7 @@ function testRequestGenerator(callback)
 				options.headers['Content-Type'] = 'application/json';
 				var request = client(options, callback);
 				request.write(message);
-				request.end();
+				return request;
 			},
 		};
 		loadtest.loadTest(options, function(error, result)


### PR DESCRIPTION
Ensure that socket hangup is caught when using requestGenerator

Furthermore, enable setting 0 as timeout (disabling). Didn't work since the logic never passed

```javascript
params.timeout = 0
if (params.timeout){ //won't work
   ...
}
```