### PR TITLE
Issue with submit form data

### DIFF
--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -125,7 +125,7 @@ function readBody(filename, option)
 		return require(path.resolve(filename));
 	}
 
-    var ret = fs.readFileSync(filename, {encoding: 'utf8'}).replace("\n", "");
+    	var ret = fs.readFileSync(filename, {encoding: 'utf8'}).replace("\n", "");
 
 	return ret;
 }

--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -125,7 +125,9 @@ function readBody(filename, option)
 		return require(path.resolve(filename));
 	}
 
-	return fs.readFileSync(filename, {encoding: 'utf8'});
+    var ret = fs.readFileSync(filename, {encoding: 'utf8'}).replace("\n", "");
+
+	return ret;
 }
 
 /**


### PR DESCRIPTION
I pull this request to fix the issue when i try to test "submit form-data"

```
loadtest "http://192.168.1.191:7007/api/v1/users/login" -n 1000 -c 5 -p test.txt -T 'application/x-www-form-urlencoded'
````

At the server, the data of the request is:
[('password', 'test\n'), ('username', 'test')]

So I try to remove "\n", and it works properly.
See the details at http://stackoverflow.com/questions/31473435/how-to-implement-stress-test-with-nodejs-loadtest