### PR TITLE
added path.resolve to require of request generator

### DIFF
--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -106,7 +106,7 @@ if (options.headers)
 }
 
 if (options.requestGenerator) {
-    options.requestGenerator = require(options.requestGenerator);
+    options.requestGenerator = require(path.resolve(options.requestGenerator));
 }
 
 options.headers = defaultHeaders;


### PR DESCRIPTION
Couldn't get the command line to resolve the require on my requestgenerator.js, so looked at the syntax for how it was requiring on the post file. Ran the tests with node test.js in the root and everything came up green so hopefully didn't break anything.