### PR TITLE
support complete result for failed request

### DIFF
--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -297,15 +297,15 @@ function HttpClient(operation, params)
 			});
 			connection.on('end', function()
 			{
-				if (connection.statusCode >= 400)
-				{
-					return callback('Status code ' + connection.statusCode, connection.statusCode);
-				}
 				var result = {
 					statusCode: connection.statusCode,
 					body: body,
 					headers: connection.headers,
 				};
+				if (connection.statusCode >= 400)
+				{
+					return callback(result, connection.statusCode);
+				}
 				callback(null, result);
 			});
 		};

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -235,9 +235,9 @@ function HttpClient(operation, params)
 			if (error)
 			{
 				log.debug('Connection %s failed: %s', id, error);
-				if (result)
+				if (error.statusCode)
 				{
-					errorCode = result;
+					errorCode = error.statusCode;
 				}
 				else
 				{
@@ -298,13 +298,16 @@ function HttpClient(operation, params)
 			connection.on('end', function()
 			{
 				var result = {
+					host: connection.connection._host,
+					path: connection.req.path,
 					statusCode: connection.statusCode,
 					body: body,
 					headers: connection.headers,
 				};
 				if (connection.statusCode >= 400)
 				{
-					return callback(result, connection.statusCode);
+					var error = result;
+					return callback(error, null);
 				}
 				callback(null, result);
 			});

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -300,6 +300,7 @@ function HttpClient(operation, params)
 				var result = {
 					host: connection.connection._host,
 					path: connection.req.path,
+					method: connection.req.method,
 					statusCode: connection.statusCode,
 					body: body,
 					headers: connection.headers,


### PR DESCRIPTION
I made little change to return complete result in error for failed request along with statusCode, response body, response headers, requestIndex, requestElapsed, contentLength and date. This pull request will help us to identify actual cause for any failed request as discussed in Issue #107 

Current Error Example:
```
error: {
  "statusCode": 404,
  "body": "{\"message\":\"Record not found in DynamoDB\",\"id\":\"1c29b194-661a-451e-a0ad-d3e37c0c71c90\"}",
  "headers": {
    "content-type": "application/json",
    "content-length": "87",
    "date": "Mon, 29 Aug 2016 14:21:41 GMT",
    "connection": "close"
  },
  "requestElapsed": 354.843266,
  "requestIndex": 0,
  "instanceIndex": 0
}
```