### PR TITLE
Fix empty body with application/x-www-form-urlencoded #154

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -12,6 +12,7 @@ const testing = require('testing');
 const urlLib = require('url');
 const http = require('http');
 const https = require('https');
+const qs = require('querystring');
 const websocket = require('websocket');
 const Log = require('log');
 const timing = require('./timing.js');
@@ -78,6 +79,9 @@ class HttpClient {
 				this.generateMessage = () => this.params.body;
 			} else if (typeof this.params.body == 'object') {
 				log.debug('Received JSON body');
+				if (this.params.contentType === 'application/x-www-form-urlencoded') {
+					this.params.body = qs.stringify(this.params.body);
+				}
 				this.generateMessage = () => this.params.body;
 			} else if (typeof this.params.body == 'function') {
 				log.debug('Received function body');


### PR DESCRIPTION
Issue: https://github.com/alexfernandez/loadtest/issues/154

Hello there!

Seems we need to `querystring.stringify` body, when content-type is `application/x-www-form-urlencoded` 🤔 

