### PR TITLE
Add configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules
 .idea
 
 package-lock.json
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -748,6 +748,46 @@ Return an HTTP error code.
 Return an HTTP error code only for the given % of requests.
 If no error code was specified, default is 500.
 
+### Configuration file
+
+It is possible to put configuration options in a file named `.loadtestrc` in your working directory or in a file whose name is specified in the `loadtest` entry of your `package.json`. The options in the file will be used only if they are not specified in the command line.
+
+The expected structure of the file is the following:
+
+```json
+{
+	"delay": "Delay the response for the given milliseconds",
+	"error": "Return an HTTP error code",
+	"percent": "Return an error (default 500) only for some % of requests",
+	"maxRequests": "Number of requests to perform",
+	"concurrency": "Number of requests to make",
+	"maxSeconds": "Max time in seconds to wait for responses",
+	"timeout": "Timeout for each request in milliseconds",
+	"method": "method to url",
+	"contentType": "MIME type for the body",
+	"body": "Data to send",
+	"file": "Send the contents of the file",
+	"cookies": {
+		"key": "value"
+	},
+	"headers": {
+		"key": "value"
+	},
+	"secureProtocol": "TLS/SSL secure protocol method to use",
+	"insecure": "Allow self-signed certificates over https",
+	"cert": "The client certificate to use",
+	"key": "The client key to use",
+	"requestGenerator": "JS module with a custom request generator function",
+	"recover": "Do not exit on socket receive errors (default)",
+	"agentKeepAlive": "Use a keep-alive http agent",
+	"proxy": "Use a proxy for requests",
+	"requestsPerSecond": "Specify the requests per second for each client",
+	"indexParam": "Replace the value of given arg with an index in the URL"
+}
+```
+
+For more information about the actual configuration file name, read the [confinode user manual](https://github.com/slune-org/confinode/blob/master/doc/en/usermanual.md#configuration-search). In the list of the [supported file types](https://github.com/slune-org/confinode/blob/master/doc/extensions.md), please note that only synchronous loaders can be used with _loadtest_.
+
 ### Complete Example
 
 The file `lib/integration.js` shows a complete example, which is also a full integration test:

--- a/bin/testserver.js
+++ b/bin/testserver.js
@@ -9,6 +9,7 @@
 // requires
 const stdio = require('stdio');
 const testServer = require('../lib/testserver');
+const config = require('../lib/config')
 
 // init
 const options = stdio.getopt({
@@ -16,6 +17,7 @@ const options = stdio.getopt({
 	error: {key: 'e', args: 1, description: 'Return an HTTP error code'},
 	percent: {key: 'p', args: 1, description: 'Return an error (default 500) only for some % of requests'},
 });
+const configuration = config.loadConfig(options)
 if (options.args && options.args.length == 1) {
 	options.port = parseInt(options.args[0], 10);
 	if (!options.port) {
@@ -31,6 +33,16 @@ if(options.delay) {
 		process.exit(1);
 	}
 	options.delay = parseInt(options.delay, 10);
+}
+
+if(!options.delay) {
+	options.delay = configuration.delay
+}
+if(!options.error) {
+	options.error = configuration.error
+}
+if(!options.percent) {
+	options.percent = configuration.percent
 }
 
 testServer.startServer(options);

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,101 @@
+"use strict";
+
+/**
+ * Support for configuration file.
+ */
+
+// requires
+const Log = require("log");
+const {
+	Confinode,
+	Level,
+	anyItem,
+	booleanItem,
+	choiceItem,
+	defaultValue,
+	dictionary,
+	literal,
+	numberItem,
+	optional,
+	stringItem
+} = require("confinode");
+
+// globals
+const log = new Log("info");
+
+/**
+ * Load configuration from file.
+ */
+exports.loadConfig = function(options) {
+	if (options.debug) {
+		log.level = Log.DEBUG;
+	}
+	if (options.quiet) {
+		log.level = Log.NOTICE;
+	}
+	const description = literal({
+		delay: numberItem(0),
+		error: numberItem(0),
+		percent: stringItem(""),
+		maxRequests: numberItem(0),
+		concurrency: numberItem(1),
+		maxSeconds: numberItem(0),
+		timeout: optional(stringItem()),
+		method: choiceItem(["GET", "POST", "PUT", "DELETE", "PATCH", "get", "post", "put", "delete", "patch"], "GET"),
+		contentType: stringItem(""),
+		body: defaultValue(anyItem(), ""),
+		file: stringItem(""),
+		cookies: defaultValue(new CookieDescription(), []),
+		headers: defaultValue(dictionary(stringItem()), {}),
+		secureProtocol: stringItem(""),
+		insecure: booleanItem(),
+		cert: stringItem(""),
+		key: stringItem(""),
+		requestGenerator: stringItem(""),
+		recover: booleanItem(true),
+		agentKeepAlive: booleanItem(),
+		proxy: stringItem(""),
+		requestsPerSecond: numberItem(0),
+		indexParam: stringItem("")
+	});
+	const confinode = new Confinode("loadtest", description, { logger, mode: "sync" });
+	const result = confinode.search();
+	return result ? result.configuration : {};
+};
+
+/**
+ * Logging function of confinode.
+ */
+function logger(msg) {
+	switch (msg.Level) {
+	case Level.Error:
+		log.error(msg.toString());
+		break;
+	case Level.Warning:
+		log.warning(msg.toString());
+		break;
+	case Level.Information:
+		log.info(msg.toString());
+		break;
+	default:
+		log.debug(msg.toString());
+	}
+}
+
+/**
+ * Description for the cookies.
+ */
+class CookieDescription {
+	constructor() {
+		this.dictionary = dictionary(stringItem());
+	}
+
+	parse(data, context) {
+		const result = this.dictionary.parse(data, context);
+		if (result) {
+			return Object.keys(result.configuration).map(key => `${key}=${result.configuration[key]}`);
+		} else {
+			return undefined;
+		}
+	}
+}

--- a/lib/integration.js
+++ b/lib/integration.js
@@ -11,6 +11,8 @@ const loadtest = require('./loadtest.js');
 const testserver = require('./testserver.js');
 const testing = require('testing');
 const Log = require('log');
+const { execFile } = require('child_process');
+const { join } = require('path');
 
 // globals
 const log = new Log('info');
@@ -47,6 +49,32 @@ function testIntegration(callback) {
 				return callback(null, 'Test results: ' + JSON.stringify(result));
 			});
 		});
+	});
+}
+
+
+/**
+ * Run an integration test using configuration file.
+ */
+function testIntegrationFile(callback) {
+	const server = testserver.startServer({ port: PORT }, error => {
+		if (error) {
+			return callback(error);
+		}
+		execFile('node',
+			[join(__dirname, '..', 'bin', 'loadtest.js'), 'http://localhost:' + PORT],
+			{ cwd: join(__dirname, '..', 'test') },
+			(error, stdout) => {
+				if (error) {
+					return callback(error);
+				}
+				server.close(error => {
+					if (error) {
+						return callback(error);
+					}
+					return callback(null, 'Test results: ' + stdout);
+				});
+			});
 	});
 }
 
@@ -126,7 +154,7 @@ function testDelay(callback) {
  */
 exports.test = function(callback) {
 	log.debug('Running all tests');
-	testing.run([testIntegration, testDelay, testWSIntegration], 4000, callback);
+	testing.run([testIntegration, testIntegrationFile, testDelay, testWSIntegration], 4000, callback);
 };
 
 // start load test if invoked directly

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	},
 	"dependencies": {
 		"agentkeepalive": "^2.0.3",
+		"confinode": "^2.1.1",
 		"https-proxy-agent": "^2.2.1",
 		"log": "1.4.*",
 		"stdio": "^0.2.3",

--- a/test/.loadtestrc
+++ b/test/.loadtestrc
@@ -1,0 +1,8 @@
+{
+  "maxRequests": 100,
+  "concurrency": 10,
+  "method": "POST",
+  "body": {
+    "hi": "there"
+  }
+}


### PR DESCRIPTION
Add the ability to set a configuration file containing default parameters. This is a quick _confinode_ integration and could probably be optimized.
Side note: since Node.js v8 is now unmaintained, _confinode_ is only supporting Node.js > v10. This may be a breaking change requiring a new major version for release…