### PR TITLE
stop latency in Operation.stop

### DIFF
--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -176,6 +176,7 @@ class Operation {
 			clearTimeout(this.stopTimeout);
 		}
 		this.running = false;
+		this.latency.running = false;
 
 		Object.keys(this.clients).forEach(index => {
 			this.clients[index].stop();


### PR DESCRIPTION
Operation.stop() is used to stop the load test if maximum running time is specified. But it did not stop the latency inside. And then it call `finalCallback` with the current latency.

latency has its own detection of maximum running time in add(), the request is added and then the latency is stopped.

This means the final latency may count one more request (and then the latency is stoppeed) then when the `finalCallback` is called.

When `quiet = false` , the final status in latency would be printed when the latency is stopped. And one can see the difference between the result printed in `finalCallback` and the latency output.

This fix stops the latency when `Operation.stop()` is called, avoiding this difference