### PR TITLE
add callback to check response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,31 @@ loadtest.loadTest(options, function(error) {
 It used to be `statusCallback(latency, result, error)`,
 it has been changed to conform to the usual Node.js standard.
 
+#### `contentInspector`
+
+A function that would be executed after every request before its status be added to the final statistics.
+
+The is can be used when you want to mark some result with 200 http status code to be failed or error.
+
+The `result` object passed to this callback function has the same fields as the `result` object passed to `statusCallback`.
+
+`customError` can be added to mark this result as failed or error. `customeErrorCode` will be provided in the final statistics, in addtion to the http status code.
+
+Example:
+
+```javascript
+fucntion contentInspector (result) => {
+    if (result.statusCode == 200) {
+        const body = JSON.parse(result.body)
+        // how to examine the body depends on the content that the service returns
+        if (body.status.err_code !== 0) {
+            result.customError = body.status.err_code + " " + body.status.msg
+            result.customErrorCode = body.status.err_code
+        }
+    }
+},
+```
+
 ### Results
 
 The latency results passed to your callback at the end of the load test contains a full set of data, including:

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ declare namespace loadtest {
 		insecure?: boolean;
 		secureProtocol?: string;
 		statusCallback?(error: Error, result: any, latency: LoadTestResult): void;
+		contentInspector?(result: any): void;
 	}
 
 	export interface LoadTestResult {

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -171,9 +171,9 @@ class HttpClient {
 			delete this.options.headers['Content-Length'];
 		}
 		if (typeof this.params.requestGenerator == 'function') {
-			request = this.params.requestGenerator(this.params, this.options, lib.request, this.getConnect(id, requestFinished));
+			request = this.params.requestGenerator(this.params, this.options, lib.request, this.getConnect(id, requestFinished, this.params.contentInspector));
 		} else {
-			request = lib.request(this.options, this.getConnect(id, requestFinished));
+			request = lib.request(this.options, this.getConnect(id, requestFinished, this.params.contentInspector));
 		}
 		if (this.params.hasOwnProperty('timeout')) {
 			const timeout = parseInt(this.params.timeout);
@@ -203,6 +203,9 @@ class HttpClient {
 				log.debug('Connection %s failed: %s', id, error);
 				if (result) {
 					errorCode = result.statusCode;
+					if (result.customErrorCode !== undefined) {
+						errorCode = errorCode + ":" + result.customErrorCode
+					}
 				} else {
 					errorCode = '-1';
 				}
@@ -232,7 +235,7 @@ class HttpClient {
 	/**
 	 * Get a function to connect the player.
 	 */
-	getConnect(id, callback) {
+	getConnect(id, callback, contentInspector) {
 		let body = '';
 		return connection => {
 			log.debug('HTTP client connected to %s with id %s', this.params.url, id);
@@ -253,8 +256,14 @@ class HttpClient {
 					body: body,
 					headers: connection.headers,
 				};
+				if (contentInspector) {
+					contentInspector(result)
+				}
 				if (connection.statusCode >= 400) {
 					return callback('Status code ' + connection.statusCode, result);
+				}
+				if (result.customError) {
+					return callback('Custom error: ' + result.customError, result);
 				}
 				callback(null, result);
 			});
@@ -277,7 +286,7 @@ function testHttpClient(callback) {
 /**
  * Run all tests.
  */
-exports.test = function(callback) {
+exports.test = function (callback) {
 	testing.run([
 		testHttpClient,
 	], callback);

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -291,7 +291,7 @@ class Latency {
 			log.info(' 100%      %s ms (longest request)', this.maxLatencyMs);
 			log.info('');
 			Object.keys(results.errorCodes).forEach(errorCode => {
-				const padding = ' '.repeat(4 - errorCode.length);
+				const padding = ' '.repeat(errorCode.length < 4 ? 4 - errorCode.length : 1);
 				log.info(' %s%s:   %s errors', padding, errorCode, results.errorCodes[errorCode]);
 			});
 		}


### PR DESCRIPTION
Met some irregular http service that do not use status code to show failure, but used some mark in the response body to show error, such as illegal parameter.

So added a callback to give use a change to inspect the response body before the request is add to statistics. User can add marks to show that this response is fact an error, despite the 200 status code.