### PR TITLE
fix undefined default headers issue

### DIFF
--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -122,7 +122,7 @@ if(options.cert) {
 	options.cert = fs.readFileSync(options.cert);
 }
 
-const defaultHeaders = options.headers ? {} : configuration.headers;
+const defaultHeaders = options.headers || !configuration.headers ? {} : configuration.headers;
 defaultHeaders['host'] = urlLib.parse(options.url).host;
 defaultHeaders['user-agent'] = 'loadtest/' + packageJson.version;
 defaultHeaders['accept'] = '*/*';


### PR DESCRIPTION
defaultHeaders['host'] = urlLib.parse(options.url).host;
                       ^
TypeError: Cannot set property 'host' of undefined