### PR TITLE
Fix websocket benchmark

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -130,7 +130,7 @@ class WebsocketClient extends BaseClient {
 				requestFinished(null, json);
 			});
 
-			let message;
+			let message={some:"message"};
 
 			if (this.generateMessage) {
 				message = this.generateMessage(id);


### PR DESCRIPTION
This change is necessary to avoid error which crops up due to the variable **message** https://github.com/alexfernandez/loadtest/blob/a5aa8de68dfa70249aa225f8aca8b5506097be15/lib/websocket.js#L149 being undefined https://github.com/alexfernandez/loadtest/blob/a5aa8de68dfa70249aa225f8aca8b5506097be15/lib/websocket.js#L133 when no requestGenerator is specified (the if conditions in both lines https://github.com/alexfernandez/loadtest/blob/a5aa8de68dfa70249aa225f8aca8b5506097be15/lib/websocket.js#L135 and https://github.com/alexfernandez/loadtest/blob/a5aa8de68dfa70249aa225f8aca8b5506097be15/lib/websocket.js#L138 are false)