### PR TITLE
Fix 'url.replaceAll is not a function'

### DIFF
--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -140,11 +140,11 @@ class Operation {
 		const url = this.options.url;
 		for (let index = 0; index < this.options.concurrency; index++) {
 			if (this.options.indexParam) {
-				this.options.url = url.replaceAll(this.options.indexParam, index);
+				this.options.url = url.replace(new RegExp(this.options.indexParam, 'g'), index);
 
 				if(this.options.body) {
 					let strBody = JSON.stringify(this.options.body);
-					strBody = strBody.replaceAll(this.options.indexParam, index);
+					strBody = strBody.replace(new RegExp(this.options.indexParam, 'g'), index);
 					this.options.body = JSON.parse(strBody);
 				}
 			}


### PR DESCRIPTION
With node version 12.x there is no replaceAll function. Use replace() with regex for more compatible instead.