### PR TITLE
fix for replacing the body with matching indexparam

### DIFF
--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -139,14 +139,14 @@ class Operation {
 	 */
 	startClients() {
 		const url = this.options.url;
+		const strBody = JSON.stringify(this.options.body);
 		for (let index = 0; index < this.options.concurrency; index++) {
 			if (this.options.indexParam) {
 				this.options.url = url.replace(new RegExp(this.options.indexParam, 'g'), index);
 
 				if(this.options.body) {
-					let strBody = JSON.stringify(this.options.body);
-					strBody = strBody.replace(new RegExp(this.options.indexParam, 'g'), index);
-					this.options.body = JSON.parse(strBody);
+					let body = strBody.replace(new RegExp(this.options.indexParam, 'g'), index);
+					this.options.body = JSON.parse(body);
 				}
 			}
 			let constructor = httpClient.create;


### PR DESCRIPTION
With requests like POST when indexParam is used, the body is not replaced with the value specified in the `options.indexparam`
This fix is to have the body change the matching string dynamically with index
