### PR TITLE
Feature/replace indexparam with custom id generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,25 @@ will be:
 * ...
 * body will also be replaced `body:{ userid: id_value }` will be `body:{ userid: id_1 }`
 
+#### `indexParamCallback`
+
+A function that would be executed to replace the value identified through `indexParam` through a custom value generator.
+
+E.g.: if URL is `http://test.com/value` and `indexParam=value` and
+```javascript
+indexParamCallback: function customCallBack() {
+  return Math.floor(Math.random() * 10); //returns a random integer from 0 to 9
+}
+``` 
+then the URL could be:
+
+* http://test.com/1 (Randomly generated integer 1)
+* http://test.com/5 (Randomly generated integer 5)
+* http://test.com/6 (Randomly generated integer 6)
+* http://test.com/8 (Randomly generated integer 8)
+* ...
+* body will also be replaced `body:{ userid: id_value }` will be `body:{ userid: id_<value from callback> }`
+
 #### `insecure`
 
 Allow invalid and self-signed certificates over https.

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare namespace loadtest {
 		secureProtocol?: string;
 		statusCallback?(error: Error, result: any, latency: LoadTestResult): void;
 		contentInspector?(result: any): void;
-		indexParamCallBack?(): string;
+		indexParamCallback?(): string;
 	}
 
 	export interface LoadTestResult {

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare namespace loadtest {
 		secureProtocol?: string;
 		statusCallback?(error: Error, result: any, latency: LoadTestResult): void;
 		contentInspector?(result: any): void;
+		indexParamCallBack?(): string;
 	}
 
 	export interface LoadTestResult {

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -88,8 +88,8 @@ let operationInstanceIndex = 0;
  */
 class Operation {
 	constructor(options, callback) {
-		this.options = options
-		this.finalCallback = callback
+		this.options = options;
+		this.finalCallback = callback;
 		this.running = true;
 		this.latency = null;
 		this.clients = {};
@@ -110,7 +110,7 @@ class Operation {
 			this.stopTimeout = setTimeout(() => this.stop(), this.options.maxSeconds * 1000).unref();
 		}
 		this.showTimer = new HighResolutionTimer(SHOW_INTERVAL_MS, () => this.latency.showPartial());
-		this.showTimer.unref()
+		this.showTimer.unref();
 	}
 
 	/**
@@ -140,13 +140,28 @@ class Operation {
 	startClients() {
 		const url = this.options.url;
 		const strBody = JSON.stringify(this.options.body);
+		function replace(str, oldToken, newToken) {
+			return str.replace(oldToken, newToken);
+		}
 		for (let index = 0; index < this.options.concurrency; index++) {
 			if (this.options.indexParam) {
-				this.options.url = url.replace(new RegExp(this.options.indexParam, 'g'), index);
+				let oldToken = new RegExp(this.options.indexParam, 'g');
+				if(this.options.indexParamCallBack instanceof Function) {
+					let customIndex = this.options.indexParamCallBack();
+					this.options.url = replace(url, oldToken, customIndex);
 
-				if(this.options.body) {
-					let body = strBody.replace(new RegExp(this.options.indexParam, 'g'), index);
-					this.options.body = JSON.parse(body);
+					if(this.options.body) {
+						let body = replace(strBody, oldToken, customIndex);
+						this.options.body = JSON.parse(body);
+					}
+				}
+				else {
+					this.options.url = replace(url, oldToken, index);
+
+					if(this.options.body) {
+						let body = replace(strBody, oldToken, index);
+						this.options.body = JSON.parse(body);
+					}
 				}
 			}
 			let constructor = httpClient.create;
@@ -219,12 +234,66 @@ function testWSEcho(callback) {
 	exports.loadTest(options, callback);
 }
 
+function testIndexParam(callback) {
+	const options = {
+		url: 'http://localhost:7357/replace',
+		concurrency:1,
+		quiet: true,
+		maxSeconds: 0.1,
+		indexParam: "replace"
+	};
+	exports.loadTest(options, callback);
+}
+
+function testIndexParamWithBody(callback) {
+	const options = {
+		url: 'http://localhost:7357/replace',
+		concurrency:1,
+		quiet: true,
+		maxSeconds: 0.1,
+		indexParam: "replace",
+		body: '{"id": "replace"}'
+	};
+	exports.loadTest(options, callback);
+}
+
+function testIndexParamWithCallback(callback) {
+	const options = {
+		url: 'http://localhost:7357/replace',
+		concurrency:1,
+		quiet: true,
+		maxSeconds: 0.1,
+		indexParam: "replace",
+		indexParamCallBack: function() {
+			//https://gist.github.com/6174/6062387
+			return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+		}
+	};
+	exports.loadTest(options, callback);
+}
+
+function testIndexParamWithCallbackAndBody(callback) {
+	const options = {
+		url: 'http://localhost:7357/replace',
+		concurrency:1,
+		quiet: true,
+		maxSeconds: 0.1,
+		body: '{"id": "replace"}',
+		indexParam: "replace",
+		indexParamCallBack: function() {
+			//https://gist.github.com/6174/6062387
+			return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+		}
+	};
+	exports.loadTest(options, callback);
+}
+
 
 /**
  * Run all tests.
  */
 exports.test = function(callback) {
-	testing.run([testMaxSeconds, testWSEcho], callback);
+	testing.run([testMaxSeconds, testWSEcho, testIndexParam, testIndexParamWithBody, testIndexParamWithCallback, testIndexParamWithCallbackAndBody], callback);
 };
 
 // run tests if invoked directly

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -140,26 +140,21 @@ class Operation {
 	startClients() {
 		const url = this.options.url;
 		const strBody = JSON.stringify(this.options.body);
-		function replace(str, oldToken, newToken) {
-			return str.replace(oldToken, newToken);
-		}
 		for (let index = 0; index < this.options.concurrency; index++) {
 			if (this.options.indexParam) {
 				let oldToken = new RegExp(this.options.indexParam, 'g');
-				if(this.options.indexParamCallBack instanceof Function) {
-					let customIndex = this.options.indexParamCallBack();
-					this.options.url = replace(url, oldToken, customIndex);
-
+				if(this.options.indexParamCallback instanceof Function) {
+					let customIndex = this.options.indexParamCallback();
+					this.options.url = url.replace(oldToken, customIndex);
 					if(this.options.body) {
-						let body = replace(strBody, oldToken, customIndex);
+						let body = strBody.replace(oldToken, customIndex);
 						this.options.body = JSON.parse(body);
 					}
 				}
 				else {
-					this.options.url = replace(url, oldToken, index);
-
+					this.options.url = url.replace(oldToken, index);
 					if(this.options.body) {
-						let body = replace(strBody, oldToken, index);
+						let body = strBody.replace(oldToken, index);
 						this.options.body = JSON.parse(body);
 					}
 				}
@@ -264,7 +259,7 @@ function testIndexParamWithCallback(callback) {
 		quiet: true,
 		maxSeconds: 0.1,
 		indexParam: "replace",
-		indexParamCallBack: function() {
+		indexParamCallback: function() {
 			//https://gist.github.com/6174/6062387
 			return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 		}
@@ -280,7 +275,7 @@ function testIndexParamWithCallbackAndBody(callback) {
 		maxSeconds: 0.1,
 		body: '{"id": "replace"}',
 		indexParam: "replace",
-		indexParamCallBack: function() {
+		indexParamCallback: function() {
 			//https://gist.github.com/6174/6062387
 			return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 		}

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -139,14 +139,14 @@ class Operation {
 	 */
 	startClients() {
 		const url = this.options.url;
+		const strBody = JSON.stringify(this.options.body);
 		for (let index = 0; index < this.options.concurrency; index++) {
 			if (this.options.indexParam) {
 				this.options.url = url.replace(new RegExp(this.options.indexParam, 'g'), index);
 
 				if(this.options.body) {
-					let strBody = JSON.stringify(this.options.body);
-					strBody = strBody.replace(new RegExp(this.options.indexParam, 'g'), index);
-					this.options.body = JSON.parse(strBody);
+					let body = strBody.replace(new RegExp(this.options.indexParam, 'g'), index);
+					this.options.body = JSON.parse(body);
 				}
 			}
 			let constructor = httpClient.create;


### PR DESCRIPTION
This will provide user the feature to replace the indexParam with. the desired value instead of the index.
This will help in cases where the entity is expected to be of certain types (UUID for example - in case of ids) and the validators fail and load testing cannot be performed. 
with this change, users can provide a generator function that can be used replace the indexparam with their desired value.