### PR TITLE
pass request labels to statusCallBack

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ loadtest.loadTest(options, function(error) {
 
 #### `statusCallback`
 
-Execution this function after every request operation completes. Provides immediate access to test results while the
+If present, this function executes after every request operation completes. Provides immediate access to test results while the
 test batch is still running. This can be used for more detailed custom logging or developing your own spreadsheet or
 statistical analysis of results.
 
@@ -671,6 +671,31 @@ loadtest.loadTest(options, function(error) {
     }
     console.log('Tests run successfully');
 });
+```
+
+ 
+In some situations request data needs to be available in the statusCallBack.
+This data can be assigned to `request.labels` in the requestGenerator:
+```javascript
+const options = {
+	// ...
+	requestGenerator: (params, options, client, callback) => {
+		// ...
+        const randomInputData = Math.random().toString().substr(2, 8);
+        const message = JSON.stringify({ randomInputData })
+		const request = client(options, callback);
+        request.labels = randomInputData;
+		request.write(message);
+		return request;
+	}
+};
+```
+
+Then in statusCallBack the labels can be accessed through `result.labels`:
+```javascript
+function statusCallback(error, result, latency) {
+    console.log(result.labels);
+}
 ```
 
 **Warning**: The format for `statusCallback` has changed in version 2.0.0 onwards.

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -256,6 +256,9 @@ class HttpClient {
 					body: body,
 					headers: connection.headers,
 				};
+				if (connection.req.labels) {
+					result.labels = connection.req.labels
+				}
 				if (contentInspector) {
 					contentInspector(result)
 				}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "loadtest",
-	"version": "5.0.3",
+	"version": "5.1.0",
 	"description": "Run load tests for your web application. Mostly ab-compatible interface, with an option to force requests per second. Includes an API for automated load testing.",
 	"homepage": "https://github.com/alexfernandez/loadtest",
 	"contributors": [


### PR DESCRIPTION
As described in [issue #195](https://github.com/alexfernandez/loadtest/issues/195), this PR adds the possibility to add a label in the request which is accessible from the statusCallBack.
I did not include the entire request object as per the issue description, that seemed a bit overkill.