### PR TITLE
Use promises for load testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,14 +802,20 @@ The second parameter contains info about the current request:
     
 ### Start Test Server
 
-To start the test server use the exported function `startServer()` with a set of options and an optional callback:
+To start the test server use the exported function `startServer()` with a set of options:
 
 ```javascript
 import {startServer} from 'loadtest'
-const server = startServer({port: 8000})
+const server = await startServer({port: 8000})
 ```
 
 This function returns an HTTP server which can be `close()`d when it is no longer useful.
+As a legacy from before promises existed,
+if the optional callback is passed then it will not behave as `async`:
+
+```
+const server = startServer({port: 8000}, error => console.error(error))
+```
 
 The following options are available.
 

--- a/README.md
+++ b/README.md
@@ -315,17 +315,15 @@ Open connections using keep-alive.
 
 Note: instead of using the default agent, this option is now an alias for `-k`.
 
-#### `--quiet` (deprecated)
+#### `--quiet`
 
 Do not show any messages.
-
-Note: deprecated in version 6+, shows a warning.
 
 #### `--debug` (deprecated)
 
 Show debug messages.
 
-Note: deprecated in version 6+, shows a warning.
+Note: deprecated in version 6+.
 
 #### `--insecure`
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ but the resulting figure is much more robust.
 `loadtest` is also quite extensible.
 Using the provided API it is very easy to integrate loadtest with your package, and run programmatic load tests.
 loadtest makes it very easy to run load tests as part of systems tests, before deploying a new version of your software.
-The results include mean response times and percentiles,
+The result includes mean response times and percentiles,
 so that you can abort deployment e.g. if 99% of the requests don't finish in 10 ms or less.
 
 ### Usage Don'ts
@@ -389,7 +389,7 @@ with concurrency 10 (only relevant results are shown):
       99%      14 ms
      100%      35997 ms (longest request)
 
-Results were quite erratic, with some requests taking up to 36 seconds;
+The result was quite erratic, with some requests taking up to 36 seconds;
 this suggests that Node.js is queueing some requests for a long time, and answering them irregularly.
 Now we will try a fixed rate of 1000 rps:
 
@@ -444,10 +444,10 @@ We now know that our server can accept 500 rps without problems.
 Not bad for a single-process naïve Node.js server...
 We may refine our results further to find at which point from 500 to 1000 rps our server breaks down.
 
-But instead let us research how to improve the results.
+But instead let us research how to improve the result.
 One obvious candidate is to add keep-alive to the requests so we don't have to create
 a new connection for every request.
-The results (with the same test server) are impressive:
+The result (with the same test server) is impressive:
 
     $ loadtest http://localhost:7357/ -t 20 -c 10 -k
     ...
@@ -665,11 +665,11 @@ loadTest(options, function(error) {
 
 #### `statusCallback`
 
-If present, this function executes after every request operation completes. Provides immediate access to test results while the
+If present, this function executes after every request operation completes. Provides immediate access to the test result while the
 test batch is still running. This can be used for more detailed custom logging or developing your own spreadsheet or
-statistical analysis of results.
+statistical analysis of the result.
 
-The results and error passed to the callback are in the same format as the results passed to the final callback.
+The result and error passed to the callback are in the same format as the result passed to the final callback.
  
 In addition, the following three properties are added to the `result` object:
 
@@ -760,9 +760,9 @@ function contentInspector(result) {
 },
 ```
 
-### Results
+### Result
 
-The latency results passed to your callback at the end of the load test contains a full set of data, including:
+The latency result passed to your callback at the end of the load test contains a full set of data, including:
 mean latency, number of errors and percentiles.
 An example follows:
 

--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -54,7 +54,7 @@ async function processAndRun(options) {
 	options.url = options.args[0];
 	try {
 		const result = await loadTest(options)
-		showResult(result)
+		showResult(options, result)
 	} catch(error) {
 		console.error(error.message)
 		help()

--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -32,8 +32,8 @@ const options = stdio.getopt({
 	insecure: {description: 'Allow self-signed certificates over https'},
 	key: {args: 1, description: 'The client key to use'},
 	cert: {args: 1, description: 'The client certificate to use'},
+	quiet: {description: 'Do not log any messages'},
 	agent: {description: 'Use a keep-alive http agent (deprecated)'},
-	quiet: {description: 'Do not log any messages (deprecated)'},
 	debug: {description: 'Show debug messages (deprecated)'}
 });
 

--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -3,6 +3,7 @@
 import {readFile} from 'fs/promises'
 import * as stdio from 'stdio'
 import {loadTest} from '../lib/loadtest.js'
+import {showResult} from '../lib/show.js'
 
 
 const options = stdio.getopt({
@@ -52,7 +53,8 @@ async function processAndRun(options) {
 	}
 	options.url = options.args[0];
 	try {
-		loadTest(options)
+		const result = await loadTest(options)
+		showResult(result)
 	} catch(error) {
 		console.error(error.message)
 		help()

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -115,10 +115,12 @@ export class Latency {
 		if (this.options.maxRequests) {
 			percent = ' (' + Math.round(100 * this.totalRequests / this.options.maxRequests) + '%)';
 		}
-		console.info('Requests: %s%s, requests per second: %s, mean latency: %s ms', this.totalRequests, percent, result.rps, result.meanLatencyMs);
-		if (this.totalErrors) {
-			percent = Math.round(100 * 10 * this.totalErrors / this.totalRequests) / 10;
-			console.info('Errors: %s, accumulated errors: %s, %s% of total requests', this.partialErrors, this.totalErrors, percent);
+		if (!this.options.quiet) {
+			console.info('Requests: %s%s, requests per second: %s, mean latency: %s ms', this.totalRequests, percent, result.rps, result.meanLatencyMs);
+			if (this.totalErrors) {
+				percent = Math.round(100 * 10 * this.totalErrors / this.totalRequests) / 10;
+				console.info('Errors: %s, accumulated errors: %s, %s% of total requests', this.partialErrors, this.totalErrors, percent);
+			}
 		}
 		this.partialTime = 0;
 		this.partialRequests = 0;

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -224,7 +224,7 @@ export class Latency {
 		}
 		this.totalsShown = true;
 		const result = this.getResult();
-		showResult(result)
+		showResult(this.options, result)
 	}
 }
 

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -1,12 +1,13 @@
 import * as crypto from 'crypto'
+import {showResult} from './show.js'
 
 
 /**
  * Latency measurements. Options can be:
  *	- maxRequests: max number of requests to measure before stopping.
  *	- maxSeconds: max seconds, alternative to max requests.
- * An optional callback(error, results) will be called with an error,
- * or the results after max is reached.
+ * An optional callback(error, result) will be called with an error,
+ * or the result after max is reached.
  */
 export class Latency {
 	constructor(options, callback) {
@@ -106,7 +107,7 @@ export class Latency {
 	showPartial() {
 		const elapsedSeconds = this.getElapsed(this.lastShown) / 1000;
 		const meanTime = this.partialTime / this.partialRequests || 0.0;
-		const results = {
+		const result = {
 			meanLatencyMs: Math.round(meanTime * 10) / 10,
 			rps: Math.round(this.partialRequests / elapsedSeconds)
 		};
@@ -114,7 +115,7 @@ export class Latency {
 		if (this.options.maxRequests) {
 			percent = ' (' + Math.round(100 * this.totalRequests / this.options.maxRequests) + '%)';
 		}
-		console.info('Requests: %s%s, requests per second: %s, mean latency: %s ms', this.totalRequests, percent, results.rps, results.meanLatencyMs);
+		console.info('Requests: %s%s, requests per second: %s, mean latency: %s ms', this.totalRequests, percent, result.rps, result.meanLatencyMs);
 		if (this.totalErrors) {
 			percent = Math.round(100 * 10 * this.totalErrors / this.totalRequests) / 10;
 			console.info('Errors: %s, accumulated errors: %s, %s% of total requests', this.partialErrors, this.totalErrors, percent);
@@ -163,14 +164,14 @@ export class Latency {
 	finish() {
 		this.running = false;
 		if (this.callback) {
-			return this.callback(null, this.getResults());
+			return this.callback(null, this.getResult());
 		}
 	}
 
 	/**
-	 * Get final results.
+	 * Get final result.
 	 */
-	getResults() {
+	getResult() {
 		const elapsedSeconds = this.getElapsed(this.initialTime) / 1000;
 		const meanTime = this.totalTime / this.totalRequests;
 		return {
@@ -215,53 +216,15 @@ export class Latency {
 	}
 
 	/**
-	 * Show final results.
+	 * Show final result.
 	 */
 	show() {
 		if (this.totalsShown) {
 			return;
 		}
 		this.totalsShown = true;
-		const results = this.getResults();
-		console.info('');
-		console.info('Target URL:          %s', this.options.url);
-		if (this.options.maxRequests) {
-			console.info('Max requests:        %s', this.options.maxRequests);
-		} else if (this.options.maxSeconds) {
-			console.info('Max time (s):        %s', this.options.maxSeconds);
-		}
-		console.info('Concurrency level:   %s', this.options.concurrency);
-		let agent = 'none';
-		if (this.options.agentKeepAlive) {
-			agent = 'keepalive';
-		}
-		console.info('Agent:               %s', agent);
-		if (this.options.requestsPerSecond) {
-			console.info('Requests per second: %s', this.options.requestsPerSecond * this.options.concurrency);
-		}
-		console.info('');
-		console.info('Completed requests:  %s', results.totalRequests);
-		console.info('Total errors:        %s', results.totalErrors);
-		console.info('Total time:          %s s', results.totalTimeSeconds);
-		console.info('Requests per second: %s', results.rps);
-		console.info('Mean latency:        %s ms', results.meanLatencyMs);
-		console.info('');
-		console.info('Percentage of the requests served within a certain time');
-
-		Object.keys(results.percentiles).forEach(percentile => {
-			console.info('  %s%      %s ms', percentile, results.percentiles[percentile]);
-		});
-
-		console.info(' 100%      %s ms (longest request)', this.maxLatencyMs);
-		if (results.totalErrors) {
-			console.info('');
-			console.info(' 100%      %s ms (longest request)', this.maxLatencyMs);
-			console.info('');
-			Object.keys(results.errorCodes).forEach(errorCode => {
-				const padding = ' '.repeat(errorCode.length < 4 ? 4 - errorCode.length : 1);
-				console.info(' %s%s:   %s errors', padding, errorCode, results.errorCodes[errorCode]);
-			});
-		}
+		const result = this.getResult();
+		showResult(result)
 	}
 }
 

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -14,33 +14,47 @@ https.globalAgent.maxSockets = 1000;
 
 /**
  * Run a load test.
- * Options is an object which may have:
- *	- url: mandatory URL to access.
- *	- concurrency: how many concurrent clients to use.
- *	- maxRequests: how many requests to send
- *	- maxSeconds: how long to run the tests.
- *	- cookies: a string or an array of strings, each with name:value.
- *	- headers: a map with headers: {key1: value1, key2: value2}.
- *	- method: the method to use: POST, PUT. Default: GET, what else.
- *	- body: the contents to send along a POST or PUT request.
- *	- contentType: the MIME type to use for the body, default text/plain.
- *	- requestsPerSecond: how many requests per second to send.
- *	- agentKeepAlive: if true, then use connection keep-alive.
- *	- indexParam: string to replace with a unique index.
- *	- insecure: allow https using self-signed certs.
- *	- debug: show debug messages (deprecated).
- *	- quiet: do not log any messages (deprecated).
- * An optional callback will be called if/when the test finishes.
+ * Parameters:
+ * - `options`: an object which may have:
+ *	 - url: mandatory URL to access.
+ *	 - concurrency: how many concurrent clients to use.
+ *	 - maxRequests: how many requests to send
+ *	 - maxSeconds: how long to run the tests.
+ *	 - cookies: a string or an array of strings, each with name:value.
+ *	 - headers: a map with headers: {key1: value1, key2: value2}.
+ *	 - method: the method to use: POST, PUT. Default: GET, what else.
+ *	 - body: the contents to send along a POST or PUT request.
+ *	 - contentType: the MIME type to use for the body, default text/plain.
+ *	 - requestsPerSecond: how many requests per second to send.
+ *	 - agentKeepAlive: if true, then use connection keep-alive.
+ *	 - indexParam: string to replace with a unique index.
+ *	 - insecure: allow https using self-signed certs.
+ *	 - debug: show debug messages (deprecated).
+ *	 - quiet: do not log any messages (deprecated).
+ * - `callback`: optional `function(result, error)` called if/when the test finishes;
+ * if not present a promise is returned.
  */
 export function loadTest(options, callback) {
-	processOptions(options, error => {
-		if (error) {
-			if (callback) return callback(error)
-			throw new error
-		}
-		const operation = new Operation(options, callback);
+	if (!callback) {
+		return loadTestAsync(options)
+	}
+	loadTestAsync(options).then(result => callback(result)).catch(error => callback(null, error))
+}
+
+async function loadTestAsync(options) {
+	await processOptions(options)
+	return await runOperation(options)
+}
+
+function runOperation(options) {
+	return new Promise((resolve, reject) => {
+		const operation = new Operation(options, (error, result) => {
+			if (error) {
+				return reject(error)
+			}
+			return resolve(result)
+		});
 		operation.start();
-		return operation;
 	})
 }
 

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -29,8 +29,8 @@ https.globalAgent.maxSockets = 1000;
  *	 - agentKeepAlive: if true, then use connection keep-alive.
  *	 - indexParam: string to replace with a unique index.
  *	 - insecure: allow https using self-signed certs.
+ *	 - quiet: do not log any messages.
  *	 - debug: show debug messages (deprecated).
- *	 - quiet: do not log any messages (deprecated).
  * - `callback`: optional `function(result, error)` called if/when the test finishes;
  * if not present a promise is returned.
  */

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -107,7 +107,7 @@ class Operation {
 			next();
 		}
 		if (this.options.statusCallback) {
-			this.options.statusCallback(error, result, this.latency.getResults());
+			this.options.statusCallback(error, result, this.latency.getResult());
 		}
 	}
 
@@ -170,7 +170,7 @@ class Operation {
 			this.clients[index].stop();
 		});
 		if (this.finalCallback) {
-			const result = this.latency.getResults();
+			const result = this.latency.getResult();
 			result.instanceIndex = this.instanceIndex;
 			this.finalCallback(null, result);
 		} else {

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -38,7 +38,7 @@ export function loadTest(options, callback) {
 	if (!callback) {
 		return loadTestAsync(options)
 	}
-	loadTestAsync(options).then(result => callback(result)).catch(error => callback(null, error))
+	loadTestAsync(options).then(result => callback(null, result)).catch(error => callback(null, error))
 }
 
 async function loadTestAsync(options) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -7,11 +7,7 @@ import {addHeaders} from '../lib/headers.js'
 import {loadConfig} from '../lib/config.js'
 
 
-export function processOptions(options, callback) {
-	processOptionsAsync(options).then(result => callback(null, result)).catch(error => callback(error))
-}
-
-async function processOptionsAsync(options) {
+export async function processOptions(options) {
 	const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url)))
 	if (!options.url) {
 		throw new Error('Missing URL in options')

--- a/lib/show.js
+++ b/lib/show.js
@@ -1,0 +1,47 @@
+
+
+/**
+ * Show result of a load test.
+ */
+export function showResult(options, result) {
+	console.info('');
+	console.info('Target URL:          %s', options.url);
+	if (options.maxRequests) {
+		console.info('Max requests:        %s', options.maxRequests);
+	} else if (options.maxSeconds) {
+		console.info('Max time (s):        %s', options.maxSeconds);
+	}
+	console.info('Concurrency level:   %s', options.concurrency);
+	let agent = 'none';
+	if (options.agentKeepAlive) {
+		agent = 'keepalive';
+	}
+	console.info('Agent:               %s', agent);
+	if (options.requestsPerSecond) {
+		console.info('Requests per second: %s', options.requestsPerSecond * options.concurrency);
+	}
+	console.info('');
+	console.info('Completed requests:  %s', result.totalRequests);
+	console.info('Total errors:        %s', result.totalErrors);
+	console.info('Total time:          %s s', result.totalTimeSeconds);
+	console.info('Requests per second: %s', result.rps);
+	console.info('Mean latency:        %s ms', result.meanLatencyMs);
+	console.info('');
+	console.info('Percentage of the requests served within a certain time');
+
+	Object.keys(result.percentiles).forEach(percentile => {
+		console.info('  %s%      %s ms', percentile, result.percentiles[percentile]);
+	});
+
+	console.info(' 100%      %s ms (longest request)', result.maxLatencyMs);
+	if (result.totalErrors) {
+		console.info('');
+		Object.keys(result.errorCodes).forEach(errorCode => {
+			const padding = ' '.repeat(errorCode.length < 4 ? 4 - errorCode.length : 1);
+			console.info(' %s%s:   %s errors', padding, errorCode, result.errorCodes[errorCode]);
+		});
+	}
+}
+
+
+

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -26,6 +26,19 @@ class TestServer {
 	 * An optional callback will be called after the server has started.
 	 */
 	start(callback) {
+		if (callback) {
+			this.startUnprotected(callback)
+			return this.server
+		}
+		return new Promise((resolve, reject) => {
+			this.startUnprotected(error => {
+				if (error) return reject(error)
+				return resolve(null, this.server)
+			})
+		})
+	}
+
+	startUnprotected(callback) {
 		if (this.options.socket) {
 			// just for internal debugging
 			this.server = net.createServer(() => this.socketListen());
@@ -45,10 +58,8 @@ class TestServer {
 			return this.createError('Could not start server on port ' + this.port + ': ' + error, callback);
 		});
 		this.server.listen(this.port, () => {
-			console.info(`Listening on http://localhost:${this.port}/`);
-			if (callback) {
-				callback();
-			}
+			if (!this.options.quiet) console.info(`Listening on http://localhost:${this.port}/`)
+			callback(null)
 		});
 		this.wsServer.on('request', request => {
 			// explicity omitting origin check here.
@@ -61,19 +72,15 @@ class TestServer {
 				}
 			});
 			connection.on('close', () => {
-				console.info('Peer %s disconnected', connection.remoteAddress);
+				if (!this.options.quiet) console.info('Peer %s disconnected', connection.remoteAddress);
 			});
 		});
-		return this.server;
 	}
 
 	/**
 	 * Log an error, or send to the callback if present.
 	 */
 	createError(message, callback) {
-		if (!callback) {
-			return console.error(message);
-		}
 		callback(message);
 	}
 
@@ -106,7 +113,7 @@ class TestServer {
 	 */
 	socketListen(socket) {
 		socket.on('error', error => {
-			console.error('socket error: %s', error);
+			if (!this.options.quiet) console.error('socket error: %s', error);
 			socket.end();
 		});
 		socket.on('data', data => this.readData(data));
@@ -116,16 +123,16 @@ class TestServer {
 	 * Read some data off the socket.
 	 */
 	readData(data) {
-		console.info('data: %s', data);
+		if (!this.options.quiet) console.info('data: %s', data);
 	}
 
 	/**
 	 * Debug headers and other interesting information: POST body.
 	 */
 	debug(request) {
-		console.info('Headers for %s to %s: %s', request.method, request.url, util.inspect(request.headers));
+		if (!this.options.quiet) console.info('Headers for %s to %s: %s', request.method, request.url, util.inspect(request.headers));
 		if (request.body) {
-			console.info('Body: %s', request.body);
+			if (!this.options.quiet) console.info('Body: %s', request.body);
 		}
 	}
 
@@ -152,7 +159,7 @@ class TestServer {
 		}
 		const percent = parseInt(this.options.percent, 10);
 		if (!percent) {
-			console.error('Invalid error percent %s', this.options.percent);
+			if (!this.options.quiet) console.error('Invalid error percent %s', this.options.percent);
 			return false;
 		}
 		return (Math.random() < percent / 100);
@@ -160,13 +167,15 @@ class TestServer {
 }
 
 /**
- * Start a test server. Options can contain:
- *	- port: the port to use, default 7357.
- *	- delay: wait the given milliseconds before answering.
- *	- quiet: do not log any messages (deprecated).
- *	- percent: give an error (default 500) on some % of requests.
- *	- error: set an HTTP error code, default is 500.
- * An optional callback is called after the server has started.
+ * Start a test server. Parameters:
+ * - `options`, can contain:
+ *	 - port: the port to use, default 7357.
+ *	 - delay: wait the given milliseconds before answering.
+ *	 - quiet: do not log any messages.
+ *	 - percent: give an error (default 500) on some % of requests.
+ *	 - error: set an HTTP error code, default is 500.
+ * - `callback`: optional callback, called after the server has started.
+ *   If not present will return a promise.
  */
 export function startServer(options, callback) {
 	const server = new TestServer(options);

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -23,22 +23,9 @@ class TestServer {
 
 	/**
 	 * Start the server.
-	 * An optional callback will be called after the server has started.
+	 * The callback parameter will be called after the server has started.
 	 */
 	start(callback) {
-		if (callback) {
-			this.startUnprotected(callback)
-			return this.server
-		}
-		return new Promise((resolve, reject) => {
-			this.startUnprotected(error => {
-				if (error) return reject(error)
-				return resolve(null, this.server)
-			})
-		})
-	}
-
-	startUnprotected(callback) {
 		if (this.options.socket) {
 			// just for internal debugging
 			this.server = net.createServer(() => this.socketListen());
@@ -59,7 +46,7 @@ class TestServer {
 		});
 		this.server.listen(this.port, () => {
 			if (!this.options.quiet) console.info(`Listening on http://localhost:${this.port}/`)
-			callback(null)
+			callback(null, this.server)
 		});
 		this.wsServer.on('request', request => {
 			// explicity omitting origin check here.
@@ -75,6 +62,7 @@ class TestServer {
 				if (!this.options.quiet) console.info('Peer %s disconnected', connection.remoteAddress);
 			});
 		});
+		return this.server
 	}
 
 	/**
@@ -179,6 +167,14 @@ class TestServer {
  */
 export function startServer(options, callback) {
 	const server = new TestServer(options);
-	return server.start(callback);
+	if (callback) {
+		return server.start(callback)
+	}
+	return new Promise((resolve, reject) => {
+		server.start((error, result) => {
+			if (error) return reject(error)
+			return resolve(result)
+		})
+	})
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "loadtest",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"type": "module",
 	"description": "Run load tests for your web application. Mostly ab-compatible interface, with an option to force requests per second. Includes an API for automated load testing.",
 	"homepage": "https://github.com/alexfernandez/loadtest",

--- a/sample/request-generator.js
+++ b/sample/request-generator.js
@@ -25,11 +25,11 @@ const options = {
 	}
 };
 
-loadTest(options, (error, results) => {
+loadTest(options, (error, result) => {
 	if (error) {
 		return console.error('Got an error: %s', error);
 	}
-	console.log(results);
+	console.log(result);
 	console.log('Tests run successfully');
 });
 

--- a/sample/request-generator.ts
+++ b/sample/request-generator.ts
@@ -25,9 +25,9 @@ const options: loadtest.LoadTestOptions = {
     },
 }
 
-loadtest.loadTest(options, (error, results) => {
+loadtest.loadTest(options, (error, result) => {
     if (error) {
         return console.error(`Got an error: ${error}`)
     }
-    console.log("Tests run successfully", {results})
+    console.log("Tests run successfully", {result})
 })

--- a/test/body-generator.js
+++ b/test/body-generator.js
@@ -16,6 +16,7 @@ function testBodyGenerator(callback) {
 			maxRequests: 100,
 			concurrency: 10,
 			postFile: 'sample/post-file.js',
+			quiet: true,
 		}
 		loadTest(options, (error, result) => {
 			if (error) {

--- a/test/body-generator.js
+++ b/test/body-generator.js
@@ -6,7 +6,7 @@ const PORT = 10453;
 
 
 function testBodyGenerator(callback) {
-	const server = startServer({port: PORT}, error => {
+	const server = startServer({port: PORT, quiet: true}, error => {
 		if (error) {
 			return callback('Could not start test server');
 		}

--- a/test/integration.js
+++ b/test/integration.js
@@ -26,6 +26,7 @@ function testIntegration(callback) {
 			body: {
 				hi: 'there',
 			},
+			quiet: true,
 		};
 		loadTest(options, (error, result) => {
 			if (error) {
@@ -51,7 +52,8 @@ function testIntegrationFile(callback) {
 			return callback(error);
 		}
 		execFile('node',
-			[join('./', 'bin', 'loadtest.js'), `http://localhost:${PORT}/`, '-n', '100'],
+			[join('./', 'bin', 'loadtest.js'), `http://localhost:${PORT}/`,
+				'-n', '100', '--quiet'],
 			(error, stdout) => {
 				if (error) {
 					return callback(error);
@@ -89,6 +91,7 @@ function testWSIntegration(callback) {
 				type: 'ping',
 				hi: 'there',
 			},
+			quiet: true,
 		};
 		loadTest(options, (error, result) => {
 			if (error) {
@@ -121,6 +124,7 @@ function testDelay(callback) {
 		options = {
 			url: 'http://localhost:' + (PORT + 1),
 			maxRequests: 10,
+			quiet: true,
 		};
 		loadTest(options, (error, result) => {
 			if (error) {
@@ -152,7 +156,6 @@ async function testPromise() {
 	};
 	const result = await loadTest(options)
 	await server.close()
-	console.log(result)
 	return 'Test result: ' + JSON.stringify(result)
 }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -133,10 +133,30 @@ function testDelay(callback) {
 	});
 }
 
+async function testPromise() {
+	const server = await startServer(serverOptions)
+	const options = {
+		url: 'http://localhost:' + PORT,
+		maxRequests: 100,
+		concurrency: 10,
+		method: 'POST',
+		body: {
+			hi: 'there',
+		},
+		quiet: true,
+	};
+	const result = await loadTest(options)
+	await server.close()
+	console.log(result)
+	return 'Test result: ' + JSON.stringify(result)
+}
+
 /**
  * Run all tests.
  */
 export function test(callback) {
-	testing.run([testIntegration, testIntegrationFile, testDelay, testWSIntegration], 4000, callback);
+	testing.run([
+		testIntegration, testIntegrationFile, testDelay, testWSIntegration, testPromise,
+	], 4000, callback);
 }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -31,7 +31,7 @@ function testIntegration(callback) {
 				if (error) {
 					return callback(error);
 				}
-				return callback(null, 'Test results: ' + JSON.stringify(result));
+				return callback(null, 'Test result: ' + JSON.stringify(result));
 			});
 		});
 	});
@@ -56,7 +56,7 @@ function testIntegrationFile(callback) {
 					if (error) {
 						return callback(error);
 					}
-					return callback(null, 'Test results: ' + stdout);
+					return callback(null, 'Test result: ' + stdout);
 				});
 			});
 	});
@@ -94,7 +94,7 @@ function testWSIntegration(callback) {
 				if (error) {
 					return callback(error);
 				}
-				return callback(null, 'Test results: ' + JSON.stringify(result));
+				return callback(null, 'Test result: ' + JSON.stringify(result));
 			});
 		});
 	});

--- a/test/integration.js
+++ b/test/integration.js
@@ -4,13 +4,17 @@ import {join} from 'path'
 import {loadTest, startServer} from '../index.js'
 
 const PORT = 10408;
+const serverOptions = {
+	port: PORT,
+	quiet: true,
+}
 
 
 /**
  * Run an integration test.
  */
 function testIntegration(callback) {
-	const server = startServer({ port: PORT }, error => {
+	const server = startServer(serverOptions, error => {
 		if (error) {
 			return callback(error);
 		}
@@ -42,7 +46,7 @@ function testIntegration(callback) {
  * Run an integration test using configuration file.
  */
 function testIntegrationFile(callback) {
-	const server = startServer({ port: PORT }, error => {
+	const server = startServer(serverOptions, error => {
 		if (error) {
 			return callback(error);
 		}
@@ -68,7 +72,7 @@ function testIntegrationFile(callback) {
  * Run an integration test.
  */
 function testWSIntegration(callback) {
-	const server = startServer({ port: PORT }, error => {
+	const server = startServer(serverOptions, error => {
 		if (error) {
 			return callback(error);
 		}

--- a/test/integration.js
+++ b/test/integration.js
@@ -112,6 +112,7 @@ function testDelay(callback) {
 	let options = {
 		port: PORT + 1,
 		delay: delay,
+		quiet: true,
 	};
 	const server = startServer(options, error => {
 		if (error) {

--- a/test/latency.js
+++ b/test/latency.js
@@ -49,7 +49,7 @@ function testLatencyPercentiles(callback) {
 	};
 	const latency = new Latency(options, error => {
 		testing.check(error, 'Error while testing latency percentiles', callback);
-		const percentiles = latency.getResults().percentiles;
+		const percentiles = latency.getResult().percentiles;
 
 		Object.keys(percentiles).forEach(percentile => {
 			testing.assert(percentiles[percentile] !== false, 'Empty percentile for %s', percentile, callback);

--- a/test/loadtest.js
+++ b/test/loadtest.js
@@ -10,6 +10,7 @@ function testMaxSeconds(callback) {
 		url: 'http://localhost:7357/',
 		maxSeconds: 0.1,
 		concurrency: 1,
+		quiet: true,
 	};
 	loadTest(options, callback);
 }
@@ -23,6 +24,7 @@ function testWSEcho(callback) {
 		url: 'ws://localhost:7357/',
 		maxSeconds: 0.1,
 		concurrency: 1,
+		quiet: true,
 	};
 	loadTest(options, callback);
 }
@@ -32,7 +34,8 @@ function testIndexParam(callback) {
 		url: 'http://localhost:7357/replace',
 		concurrency:1,
 		maxSeconds: 0.1,
-		indexParam: "replace"
+		indexParam: "replace",
+		quiet: true,
 	};
 	loadTest(options, callback);
 }
@@ -43,7 +46,8 @@ function testIndexParamWithBody(callback) {
 		concurrency:1,
 		maxSeconds: 0.1,
 		indexParam: "replace",
-		body: '{"id": "replace"}'
+		body: '{"id": "replace"}',
+		quiet: true,
 	};
 	loadTest(options, callback);
 }
@@ -57,7 +61,8 @@ function testIndexParamWithCallback(callback) {
 		indexParamCallback: function() {
 			//https://gist.github.com/6174/6062387
 			return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
-		}
+		},
+		quiet: true,
 	};
 	loadTest(options, callback);
 }
@@ -72,7 +77,8 @@ function testIndexParamWithCallbackAndBody(callback) {
 		indexParamCallback: function() {
 			//https://gist.github.com/6174/6062387
 			return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
-		}
+		},
+		quiet: true,
 	};
 	loadTest(options, callback);
 }
@@ -82,6 +88,9 @@ function testIndexParamWithCallbackAndBody(callback) {
  * Run all tests.
  */
 export function test(callback) {
-	testing.run([testMaxSeconds, testWSEcho, testIndexParam, testIndexParamWithBody, testIndexParamWithCallback, testIndexParamWithCallbackAndBody], callback);
+	testing.run([
+		testMaxSeconds, testWSEcho, testIndexParam, testIndexParamWithBody,
+		testIndexParamWithCallback, testIndexParamWithCallbackAndBody,
+	], callback);
 }
 

--- a/test/request-generator.js
+++ b/test/request-generator.js
@@ -6,7 +6,7 @@ const PORT = 10453;
 
 
 function testRequestGenerator(callback) {
-	const server = startServer({port: PORT}, error => {
+	const server = startServer({port: PORT, quiet: true}, error => {
 		if (error) {
 			return callback('Could not start test server');
 		}

--- a/test/request-generator.js
+++ b/test/request-generator.js
@@ -24,6 +24,7 @@ function testRequestGenerator(callback) {
 				request.write(message);
 				return request;
 			},
+			quiet: true,
 		};
 		loadTest(options, (error, result) => {
 			if (error) {

--- a/test/testserver.js
+++ b/test/testserver.js
@@ -5,6 +5,7 @@ import {startServer} from '../lib/testserver.js'
 function testStartServer(callback) {
 	const options = {
 		port: 10530,
+		quiet: true,
 	};
 	const server = startServer(options, error => {
 		testing.check(error, 'Could not start server', callback);


### PR DESCRIPTION
Use promises for load testing and starting a test server. Optionally keep callback for backwards compatibility.

Other changes:

* Restore `--quiet` in load testing and test server.

For immediate merge. Will publish as v6.1.0.