### PR TITLE
Show requests per second in test server

### DIFF
--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -5,7 +5,7 @@ import * as net from 'net'
 import {Latency} from './latency.js'
 
 const PORT = 7357;
-const LOG_HEADERS_INTERVAL_SECONDS = 1;
+const LOG_HEADERS_INTERVAL_MS = 5000;
 
 
 /**
@@ -18,6 +18,7 @@ class TestServer {
 		this.server = null;
 		this.wsServer = null;
 		this.latency = new Latency({});
+		this.totalRequests = 0
 		this.debuggedTime = Date.now();
 	}
 
@@ -82,10 +83,10 @@ class TestServer {
 			request.body += data.toString();
 		});
 		request.on('end', () => {
-			const now = Date.now();
-			if (now - this.debuggedTime > LOG_HEADERS_INTERVAL_SECONDS * 1000) {
-				this.debug(request);
-				this.debuggedTime = now;
+			this.totalRequests += 1
+			const elapsedMs = Date.now() - this.debuggedTime
+			if (elapsedMs > LOG_HEADERS_INTERVAL_MS) {
+				this.debug(request, elapsedMs);
 			}
 			if (!this.options.delay) {
 				return this.end(response, id);
@@ -118,10 +119,18 @@ class TestServer {
 	 * Debug headers and other interesting information: POST body.
 	 */
 	debug(request) {
-		if (!this.options.quiet) console.info('Headers for %s to %s: %s', request.method, request.url, util.inspect(request.headers));
+		if (this.options.quiet) return
+		const headers = util.inspect(request.headers)
+		const now = Date.now()
+		const elapsedMs = now - this.debuggedTime
+		const rps = (this.totalRequests / elapsedMs) * 1000
+		console.info(`Requests per second: ${rps.toFixed(0)}`)
+		console.info(`Headers for ${request.method} to ${request.url}: ${headers}`)
 		if (request.body) {
-			if (!this.options.quiet) console.info('Body: %s', request.body);
+			console.info(`Body: ${request.body}`);
 		}
+		this.debuggedTime = now;
+		this.totalRequests = 0
 	}
 
 	/**

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -124,7 +124,9 @@ class TestServer {
 		const now = Date.now()
 		const elapsedMs = now - this.debuggedTime
 		const rps = (this.totalRequests / elapsedMs) * 1000
-		console.info(`Requests per second: ${rps.toFixed(0)}`)
+		if (rps > 1) {
+			console.info(`Requests per second: ${rps.toFixed(0)}`)
+		}
 		console.info(`Headers for ${request.method} to ${request.url}: ${headers}`)
 		if (request.body) {
 			console.info(`Body: ${request.body}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "loadtest",
-	"version": "6.2.1",
+	"version": "6.2.2",
 	"type": "module",
 	"description": "Run load tests for your web application. Mostly ab-compatible interface, with an option to force requests per second. Includes an API for automated load testing.",
 	"homepage": "https://github.com/alexfernandez/loadtest",


### PR DESCRIPTION
Show rps in test server every five minutes, only if they are > 1.

For immediate merge, will be released as 6.2.2.