### PR TITLE
Replace indexParam correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,6 +884,11 @@ Return an HTTP error code.
 Return an HTTP error code only for the given % of requests.
 If no error code was specified, default is 500.
 
+#### `logger`
+
+A function to be called as `logger(request, response)` after every request served by the test server.
+Where `request` and `response` are the usual HTTP objects.
+
 ### Configuration file
 
 It is possible to put configuration options in a file named `.loadtestrc` in your working directory or in a file whose name is specified in the `loadtest` entry of your `package.json`. The options in the file will be used only if they are not specified in the command line.

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -90,6 +90,12 @@ class HttpClient {
 		if (this.params.secureProtocol) {
 			this.options.secureProtocol = this.params.secureProtocol;
 		}
+		// adding proxy configuration
+		if (this.params.proxy) {
+			const proxy = this.params.proxy;
+			const agent = new HttpsProxyAgent(proxy);
+			this.options.agent = agent;
+		}
 	}
 
 	/**
@@ -137,15 +143,6 @@ class HttpClient {
 		if (this.options.protocol == 'ws:') {
 			lib = websocket;
 		}
-
-		// adding proxy configuration
-		if (this.params.proxy) {
-			const proxy = this.params.proxy;
-			const agent = new HttpsProxyAgent(proxy);
-			this.options.agent = agent;
-		}
-
-
 		// Disable certificate checking
 		if (this.params.insecure === true) {
 			process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -147,8 +147,6 @@ class HttpClient {
 		const options = {...this.options, headers: {...this.options.headers}}
 		const requestFinished = this.getRequestFinisher(id);
 		this.customizeIndex(options)
-		const message = this.getMessage(id, options)
-		console.log(message)
 		const request = this.getRequest(id, options, requestFinished)
 		if (this.params.timeout) {
 			const timeout = parseInt(this.params.timeout);
@@ -159,8 +157,10 @@ class HttpClient {
 				requestFinished('Connection timed out');
 			});
 		}
+		const message = this.getMessage(id, options)
 		if (message) {
 			request.write(message);
+			options.headers['Content-Length'] = Buffer.byteLength(message);
 		}
 		request.on('error', error => {
 			requestFinished('Connection error: ' + error.message);
@@ -197,12 +197,10 @@ class HttpClient {
 
 	getMessage(id, options) {
 		if (!this.generateMessage) {
-			delete options.headers['Content-Length'];
 			return
 		}
 		const candidate = this.generateMessage(id);
 		const message = typeof candidate === 'object' ? JSON.stringify(candidate) : candidate
-		options.headers['Content-Length'] = Buffer.byteLength(message);
 		if (this.options.indexParamFinder) {
 			return message.replace(this.options.indexParamFinder, options.customIndex);
 		}

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -101,6 +101,10 @@ class HttpClient {
 		if (this.params.indexParam) {
 			this.options.indexParamFinder = new RegExp(this.params.indexParam, 'g');
 		}
+		// Disable certificate checking
+		if (this.params.insecure === true) {
+			process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+		}
 	}
 
 	/**
@@ -142,10 +146,6 @@ class HttpClient {
 		const id = this.operation.latency.start();
 		const options = {...this.options, headers: {...this.options.headers}}
 		const requestFinished = this.getRequestFinisher(id);
-		// Disable certificate checking
-		if (this.params.insecure === true) {
-			process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-		}
 		this.customizeIndex(options)
 		const message = this.getMessage(id, options)
 		console.log(message)

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -9,6 +9,8 @@ import * as agentkeepalive from 'agentkeepalive'
 import * as HttpsProxyAgent from 'https-proxy-agent'
 
 
+let uniqueIndex = 1
+
 /**
  * Create a new HTTP client.
  * Seem parameters below.
@@ -96,6 +98,11 @@ class HttpClient {
 			const agent = new HttpsProxyAgent(proxy);
 			this.options.agent = agent;
 		}
+		if (this.params.indexParam) {
+			this.options.indexParamFinder = new RegExp(this.params.indexParam, 'g');
+			// keep original path to replace with indexParam
+			this.options.originalPath = this.options.path
+		}
 	}
 
 	/**
@@ -140,6 +147,7 @@ class HttpClient {
 		if (this.params.insecure === true) {
 			process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 		}
+		this.customizeIndex()
 		const message = this.getMessage(id)
 		const request = this.getRequest(id, requestFinished)
 		if (this.params.timeout) {
@@ -160,6 +168,23 @@ class HttpClient {
 		request.end();
 	}
 
+	customizeIndex() {
+		if (!this.options.indexParamFinder) {
+			return
+		}
+		this.options.customIndex = this.getCustomIndex()
+		this.options.path = this.options.originalPath.replace(this.options.indexParamFinder, this.options.customIndex);
+	}
+
+	getCustomIndex() {
+		if (this.options.indexParamCallback instanceof Function) {
+			return this.options.indexParamCallback();
+		}
+		const customIndex = uniqueIndex
+		uniqueIndex += 1
+		return customIndex
+	}
+
 	getLib() {
 		if (this.options.protocol == 'https:') {
 			return https;
@@ -178,6 +203,9 @@ class HttpClient {
 		const candidate = this.generateMessage(id);
 		const message = typeof candidate === 'object' ? JSON.stringify(candidate) : candidate
 		this.options.headers['Content-Length'] = Buffer.byteLength(message);
+		if (this.options.indexParamFinder) {
+			return message.replace(this.options.indexParamFinder, this.options.customIndex);
+		}
 		return message
 	}
 

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -136,33 +136,12 @@ class HttpClient {
 
 		const id = this.operation.latency.start();
 		const requestFinished = this.getRequestFinisher(id);
-		let lib = http;
-		if (this.options.protocol == 'https:') {
-			lib = https;
-		}
-		if (this.options.protocol == 'ws:') {
-			lib = websocket;
-		}
 		// Disable certificate checking
 		if (this.params.insecure === true) {
 			process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 		}
-		let request, message;
-		if (this.generateMessage) {
-			message = this.generateMessage(id);
-			if (typeof message === 'object') {
-				message = JSON.stringify(message);
-			}
-			this.options.headers['Content-Length'] = Buffer.byteLength(message);
-		} else {
-			delete this.options.headers['Content-Length'];
-		}
-		if (typeof this.params.requestGenerator == 'function') {
-			const connect = this.getConnect(id, requestFinished, this.params.contentInspector)
-			request = this.params.requestGenerator(this.params, this.options, lib.request, connect);
-		} else {
-			request = lib.request(this.options, this.getConnect(id, requestFinished, this.params.contentInspector));
-		}
+		const message = this.getMessage(id)
+		const request = this.getRequest(id, requestFinished)
 		if (this.params.timeout) {
 			const timeout = parseInt(this.params.timeout);
 			if (!timeout) {
@@ -179,6 +158,36 @@ class HttpClient {
 			requestFinished('Connection error: ' + error.message);
 		});
 		request.end();
+	}
+
+	getLib() {
+		if (this.options.protocol == 'https:') {
+			return https;
+		}
+		if (this.options.protocol == 'ws:') {
+			return websocket;
+		}
+		return http;
+	}
+
+	getMessage(id) {
+		if (!this.generateMessage) {
+			delete this.options.headers['Content-Length'];
+			return
+		}
+		const candidate = this.generateMessage(id);
+		const message = typeof candidate === 'object' ? JSON.stringify(candidate) : candidate
+		this.options.headers['Content-Length'] = Buffer.byteLength(message);
+		return message
+	}
+
+	getRequest(id, requestFinished) {
+		const lib = this.getLib()
+		if (typeof this.params.requestGenerator == 'function') {
+			const connect = this.getConnect(id, requestFinished, this.params.contentInspector)
+			return this.params.requestGenerator(this.params, this.options, lib.request, connect);
+		}
+		return lib.request(this.options, this.getConnect(id, requestFinished, this.params.contentInspector));
 	}
 
 	/**

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -100,8 +100,6 @@ class HttpClient {
 		}
 		if (this.params.indexParam) {
 			this.options.indexParamFinder = new RegExp(this.params.indexParam, 'g');
-			// keep original path to replace with indexParam
-			this.options.originalPath = this.options.path
 		}
 	}
 
@@ -142,14 +140,16 @@ class HttpClient {
 		this.operation.requests += 1;
 
 		const id = this.operation.latency.start();
+		const options = {...this.options, headers: {...this.options.headers}}
 		const requestFinished = this.getRequestFinisher(id);
 		// Disable certificate checking
 		if (this.params.insecure === true) {
 			process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 		}
-		this.customizeIndex()
-		const message = this.getMessage(id)
-		const request = this.getRequest(id, requestFinished)
+		this.customizeIndex(options)
+		const message = this.getMessage(id, options)
+		console.log(message)
+		const request = this.getRequest(id, options, requestFinished)
 		if (this.params.timeout) {
 			const timeout = parseInt(this.params.timeout);
 			if (!timeout) {
@@ -168,12 +168,12 @@ class HttpClient {
 		request.end();
 	}
 
-	customizeIndex() {
+	customizeIndex(options) {
 		if (!this.options.indexParamFinder) {
 			return
 		}
-		this.options.customIndex = this.getCustomIndex()
-		this.options.path = this.options.originalPath.replace(this.options.indexParamFinder, this.options.customIndex);
+		options.customIndex = this.getCustomIndex()
+		options.path = this.options.path.replace(this.options.indexParamFinder, options.customIndex);
 	}
 
 	getCustomIndex() {
@@ -195,27 +195,27 @@ class HttpClient {
 		return http;
 	}
 
-	getMessage(id) {
+	getMessage(id, options) {
 		if (!this.generateMessage) {
-			delete this.options.headers['Content-Length'];
+			delete options.headers['Content-Length'];
 			return
 		}
 		const candidate = this.generateMessage(id);
 		const message = typeof candidate === 'object' ? JSON.stringify(candidate) : candidate
-		this.options.headers['Content-Length'] = Buffer.byteLength(message);
+		options.headers['Content-Length'] = Buffer.byteLength(message);
 		if (this.options.indexParamFinder) {
-			return message.replace(this.options.indexParamFinder, this.options.customIndex);
+			return message.replace(this.options.indexParamFinder, options.customIndex);
 		}
 		return message
 	}
 
-	getRequest(id, requestFinished) {
+	getRequest(id, options, requestFinished) {
 		const lib = this.getLib()
 		if (typeof this.params.requestGenerator == 'function') {
 			const connect = this.getConnect(id, requestFinished, this.params.contentInspector)
-			return this.params.requestGenerator(this.params, this.options, lib.request, connect);
+			return this.params.requestGenerator(this.params, options, lib.request, connect);
 		}
-		return lib.request(this.options, this.getConnect(id, requestFinished, this.params.contentInspector));
+		return lib.request(options, this.getConnect(id, requestFinished, this.params.contentInspector));
 	}
 
 	/**

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -123,7 +123,7 @@ class Operation {
 		for (let index = 0; index < this.options.concurrency; index++) {
 			if (this.options.indexParam) {
 				let oldToken = new RegExp(this.options.indexParam, 'g');
-				if(this.options.indexParamCallback instanceof Function) {
+				if (this.options.indexParamCallback instanceof Function) {
 					let customIndex = this.options.indexParamCallback();
 					this.options.url = url.replace(oldToken, customIndex);
 					if(this.options.body) {

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -23,7 +23,7 @@ https.globalAgent.maxSockets = 1000;
  *	 - cookies [array]: a string or an array of strings, each with name:value.
  *	 - headers [map]: a map with headers: {key1: value1, key2: value2}.
  *	 - method [string]: the method to use: POST, PUT. Default: GET, what else.
- *	 - body [string]: the contents to send along a POST or PUT request.
+ *	 - data [string]: the contents to send along a POST or PUT request.
  *	 - contentType [string]: the MIME type to use for the body, default text/plain.
  *	 - requestsPerSecond [number]: how many requests per second to send.
  *	 - agentKeepAlive: if true, then use connection keep-alive.

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -122,19 +122,19 @@ class Operation {
 		const strBody = JSON.stringify(this.options.body);
 		for (let index = 0; index < this.options.concurrency; index++) {
 			if (this.options.indexParam) {
-				const oldToken = new RegExp(this.options.indexParam, 'g');
+				const indexParamFinder = new RegExp(this.options.indexParam, 'g');
 				if (this.options.indexParamCallback instanceof Function) {
 					let customIndex = this.options.indexParamCallback();
-					this.options.url = url.replace(oldToken, customIndex);
+					this.options.url = url.replace(indexParamFinder, customIndex);
 					if(this.options.body) {
-						let body = strBody.replace(oldToken, customIndex);
+						let body = strBody.replace(indexParamFinder, customIndex);
 						this.options.body = JSON.parse(body);
 					}
 				}
 				else {
-					this.options.url = url.replace(oldToken, index);
+					this.options.url = url.replace(indexParamFinder, index);
 					if(this.options.body) {
-						let body = strBody.replace(oldToken, index);
+						let body = strBody.replace(indexParamFinder, index);
 						this.options.body = JSON.parse(body);
 					}
 				}

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -118,27 +118,7 @@ class Operation {
 	 * Start a number of measuring clients.
 	 */
 	startClients() {
-		const url = this.options.url;
-		const strBody = JSON.stringify(this.options.body);
 		for (let index = 0; index < this.options.concurrency; index++) {
-			if (this.options.indexParam) {
-				const indexParamFinder = new RegExp(this.options.indexParam, 'g');
-				if (this.options.indexParamCallback instanceof Function) {
-					let customIndex = this.options.indexParamCallback();
-					this.options.url = url.replace(indexParamFinder, customIndex);
-					if(this.options.body) {
-						let body = strBody.replace(indexParamFinder, customIndex);
-						this.options.body = JSON.parse(body);
-					}
-				}
-				else {
-					this.options.url = url.replace(indexParamFinder, index);
-					if(this.options.body) {
-						let body = strBody.replace(indexParamFinder, index);
-						this.options.body = JSON.parse(body);
-					}
-				}
-			}
 			const createClient = this.getClientCreator()
 			const client = createClient(this, this.options);
 			this.clients[index] = client;

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -122,7 +122,7 @@ class Operation {
 		const strBody = JSON.stringify(this.options.body);
 		for (let index = 0; index < this.options.concurrency; index++) {
 			if (this.options.indexParam) {
-				let oldToken = new RegExp(this.options.indexParam, 'g');
+				const oldToken = new RegExp(this.options.indexParam, 'g');
 				if (this.options.indexParamCallback instanceof Function) {
 					let customIndex = this.options.indexParamCallback();
 					this.options.url = url.replace(oldToken, customIndex);
@@ -139,12 +139,8 @@ class Operation {
 					}
 				}
 			}
-			let constructor = httpClient.create;
-			// TODO: || this.options.url.startsWith('wss:'))
-			if (this.options.url.startsWith('ws:')) {
-				constructor = websocket.create;
-			}
-			const client = constructor(this, this.options);
+			const createClient = this.getClientCreator()
+			const client = createClient(this, this.options);
 			this.clients[index] = client;
 			if (!this.options.requestsPerSecond) {
 				client.start();
@@ -154,6 +150,14 @@ class Operation {
 				setTimeout(() => client.start(), offset);
 			}
 		}
+	}
+
+	getClientCreator() {
+		// TODO: || this.options.url.startsWith('wss:'))
+		if (this.options.url.startsWith('ws:')) {
+			return websocket.create;
+		}
+		return httpClient.create;
 	}
 
 	/**

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -33,6 +33,7 @@ https.globalAgent.maxSockets = 1000;
  *	 - proxy [string]: use a proxy for requests e.g. http://localhost:8080.
  *	 - quiet: do not log any messages.
  *	 - debug: show debug messages (deprecated).
+ *	 - requestGenerator [function]: use a custom function to generate requests.
  * - `callback`: optional `function(result, error)` called if/when the test finishes;
  * if not present a promise is returned.
  */

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -16,6 +16,7 @@ const LOG_HEADERS_INTERVAL_MS = 5000;
  *	 - quiet: do not log any messages.
  *	 - percent: give an error (default 500) on some % of requests.
  *	 - error: set an HTTP error code, default is 500.
+ *	 - logger: function to log all incoming requests.
  * - `callback`: optional callback, called after the server has started.
  *   If not present will return a promise.
  */
@@ -118,10 +119,10 @@ class TestServer {
 				this.debug(request, elapsedMs);
 			}
 			if (!this.options.delay) {
-				return this.end(response, id);
+				return this.end(request, response, id);
 			}
 			setTimeout(() => {
-				this.end(response, id);
+				this.end(request, response, id);
 			}, this.options.delay).unref();
 		});
 	}
@@ -167,7 +168,7 @@ class TestServer {
 	/**
 	 * End the response now.
 	 */
-	end(response, id) {
+	end(request, response, id) {
 		if (this.shouldError()) {
 			const code = this.options.error || 500;
 			response.writeHead(code);
@@ -176,6 +177,9 @@ class TestServer {
 			response.end('OK');
 		}
 		this.latency.end(id);
+		if (this.options.logger) {
+			this.options.logger(request, response)
+		}
 	}
 
 	shouldError() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "loadtest",
-	"version": "6.3.2",
+	"version": "6.4.0",
 	"type": "module",
 	"description": "Run load tests for your web application. Mostly ab-compatible interface, with an option to force requests per second. Includes an API for automated load testing.",
 	"homepage": "https://github.com/alexfernandez/loadtest",

--- a/test/integration.js
+++ b/test/integration.js
@@ -159,12 +159,41 @@ async function testPromise() {
 	return 'Test result: ' + JSON.stringify(result)
 }
 
+async function testIndexParam() {
+	const urls = new Map()
+	const bodies = new Map()
+	function logger(request) {
+		if (urls.has(request.url)) {
+			throw new Error(`Duplicated url ${request.url}`)
+		}
+		urls.set(request.url, true)
+		if (bodies.has(request.body)) {
+			throw new Error(`Duplicated body ${request.body}`)
+		}
+		bodies.set(request.body, true)
+	}
+	const server = await startServer({logger, ...serverOptions})
+	const options = {
+		url: `http://localhost:${PORT}/?param=index`,
+		maxRequests: 100,
+		concurrency: 10,
+		postBody: {
+			hi: 'my_index',
+		},
+		indexParam: 'index',
+		quiet: true,
+	};
+	await loadTest(options)
+	await server.close()
+}
+
 /**
  * Run all tests.
  */
 export function test(callback) {
 	testing.run([
-		testIntegration, testIntegrationFile, testDelay, testWSIntegration, testPromise,
+		testIntegration, testIntegrationFile, testDelay, testWSIntegration,
+		testPromise, testIndexParam,
 	], 4000, callback);
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/alexfernandez/loadtest/issues/198.

The option `indexParam` was being replaced statically for every HTTP client. Now it's replaced dynamically before every request.

Also in this PR:

* Do more request setup stuff statically when initializing.
* Create dynamic options.
* Add a `logger` option to test server API.
* Add a test for `indexParam` that actually checks that the URLs change.

Performance has now increased from 12k to 16k rps (`--cores 3`) on my i5 processor.

For immediate release as v6.4.0.