### PR TITLE
Use TCP sockets for connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,8 @@ see [doc/api.md](doc/api.md) for details.
 * `percent`: return error only for the given % of requests.
 * `logger(request, response)`: function to call after every request.
 
+Returns a test server that you can `close()` when finished.
+
 ### Configuration file
 
 It is possible to put configuration options in a file named `.loadtestrc` in your working directory or in a file whose name is specified in the `loadtest` entry of your `package.json`. The options in the file will be used only if they are not specified in the command line.

--- a/README.md
+++ b/README.md
@@ -116,43 +116,53 @@ It may need installing from source though, and its interface is not `ab`-compati
 
 The following parameters are compatible with Apache ab.
 
-#### `-n requests`
+#### `-t`, `--maxSeconds`
+
+Max number of seconds to wait until requests no longer go out.
+Default is 10 seconds, applies only if no `--maxRequests` is specified.
+
+Note: this is different than Apache `ab`, which stops _receiving_ requests after the given seconds.
+
+#### `-n`, `--maxRequests`
 
 Number of requests to send out.
-Default is no limit; will keep on sending if not specified.
+Default is no limit;
+will keep on sending until the time limit in `--maxSeconds` is reached.
 
 Note: the total number of requests sent can be bigger than the parameter if there is a concurrency parameter;
 loadtest will report just the first `n`.
 
-#### `-c concurrency`
+#### `-c`, `--concurrency`
 
 loadtest will create a certain number of clients; this parameter controls how many.
 Requests from them will arrive concurrently to the server.
-Default value is 1.
+Default value is 10.
 
 Note: requests are not sent in parallel (from different processes),
 but concurrently (a second request may be sent before the first has been answered).
+Does not apply if `--requestsPerSecond` is specified.
 
-#### `-t timelimit`
+Beware: if concurrency is too low then it is possible that there will not be enough clients
+to send all the supported traffic,
+adjust it with `-c` if needed.
 
-Max number of seconds to wait until requests no longer go out.
-Default is no limit; will keep on sending if not specified.
+**Warning**: concurrency used to have a default value of 1,
+until it was changed to 10 in version 8.
 
-Note: this is different than Apache `ab`, which stops _receiving_ requests after the given seconds.
+#### `-k`, `--keepalive`
 
-#### `-k` or `--keepalive`
-
-Open connections using keep-alive: use header 'Connection: Keep-alive' instead of 'Connection: Close'.
+Open connections using keep-alive:
+use header `Connection: keep-alive` instead of `Connection: close`.
 
 Note: Uses [agentkeepalive](https://npmjs.org/package/agentkeepalive),
 which performs better than the default node.js agent.
 
-#### `-C cookie-name=value`
+#### `-C`, `--cookie cookie-name=value`
 
 Send a cookie with the request. The cookie `name=value` is then sent to the server.
 This parameter can be repeated as many times as needed.
 
-#### `-H header:value`
+#### `-H`, `--header header:value`
 
 Send a custom header with the request. The line `header:value` is then sent to the server.
 This parameter can be repeated as many times as needed.
@@ -172,19 +182,19 @@ Note: if you need to add a header with spaces, be sure to surround both header a
 
     $ loadtest -H "Authorization: Basic xxx=="
 
-#### `-T content-type`
+#### `-T`, `--contentType`
 
 Set the MIME content type for POST data. Default: `text/plain`.
 
-#### `-P POST-body`
+#### `-P`, `--postBody`
 
 Send the string as the POST body. E.g.: `-P '{"key": "a9acf03f"}'`
 
-#### `-A PATCH-body`
+#### `-A`, `--patchBody`
 
 Send the string as the PATCH body. E.g.: `-A '{"key": "a9acf03f"}'`
 
-#### `-m method`
+#### `-m`, `--method`
 
 Set method that will be sent to the test URL.
 Accepts: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`,
@@ -198,7 +208,7 @@ Requires setting the method with `-m` and the type with `-T`.
 Example: `--data '{"username": "test", "password": "test"}' -T 'application/x-www-form-urlencoded' -m POST`
 
 
-#### `-p POST-file`
+#### `-p`, `--postFile`
 
 Send the data contained in the given file in the POST body.
 Remember to set `-T` to the correct content-type.
@@ -222,7 +232,7 @@ export default function request(requestId) {
 
 See sample file in `sample/post-file.js`, and test in `test/body-generator.js`.
 
-#### `-u PUT-file`
+#### `-u`, `--putFile`
 
 Send the data contained in the given file as a PUT request.
 Remember to set `-T` to the correct content-type.
@@ -233,7 +243,7 @@ to provide the body of each request.
 This is useful if you want to generate request bodies dynamically and vary them for each request.
 For examples see above for `-p`.
 
-#### `-a PATCH-file`
+#### `-a`, `--patchFile`
 
 Send the data contained in the given file as a PATCH request.
 Remember to set `-T` to the correct content-type.
@@ -244,12 +254,12 @@ to provide the body of each request.
 This is useful if you want to generate request bodies dynamically and vary them for each request.
 For examples see above for `-p`.
 
-##### `-r recover`
+##### `-r`, `--recover`
 
 Recover from errors. Always active: loadtest does not stop on errors.
 After the tests are finished, if there were errors a report with all error codes will be shown.
 
-#### `-s secureProtocol`
+#### `-s`, `--secureProtocol`
 
 The TLS/SSL method to use. (e.g. TLSv1_method)
 
@@ -257,7 +267,7 @@ Example:
 
     $ loadtest -n 1000 -s TLSv1_method https://www.example.com
 
-#### `-V version`
+#### `-V`, `--version`
 
 Show version number and exit.
 
@@ -265,25 +275,17 @@ Show version number and exit.
 
 The following parameters are _not_ compatible with Apache ab.
 
-#### `--rps requestsPerSecond`
+#### `--rps`, `--requestsPerSecond`
 
 Controls the number of requests per second that are sent.
 Cannot be fractional, e.g. `--rps 0.5`.
 In this mode each request is not sent as soon as the previous one is responded,
 but periodically even if previous requests have not been responded yet.
 
-Note: Concurrency doesn't affect the final number of requests per second,
-since rps will be shared by all the clients. E.g.:
+Note: the `--concurrency` option will be ignored if `--requestsPerSecond` is specified;
+clients will be created on demand.
 
-    loadtest <url> -c 10 --rps 10
-
-will send a total of 10 rps to the given URL, from 10 different clients
-(each client will send 1 request per second).
-
-Beware: if concurrency is too low then it is possible that there will not be enough clients
-to send all of the rps, adjust it with `-c` if needed.
-
-Note: --rps is not supported for websockets.
+Note: `--rps` is not supported for websockets.
 
 #### `--cores number`
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Not all options are supported.
 
 **Warning**: experimental option.
 May not work with your test case.
+See [TCP Sockets Performance](doc/tcp-sockets.md) for details.
 
 ### Test Server
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Default is 10 seconds, applies only if no `--maxRequests` is specified.
 
 Note: this is different than Apache `ab`, which stops _receiving_ requests after the given seconds.
 
+**Warning**: max seconds used to have no default value,
+so tests would run indefinitely if no `--maxSeconds` and no `--maxRequests` were specified.
+Max seconds was changed to default to 10 in version 8.
+
 #### `-n`, `--maxRequests`
 
 Number of requests to send out.

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Setting this to 0 disables timeout (default).
 #### `-R requestGeneratorModule.js`
 
 Use a custom request generator function from an external file.
-See an example of a request generator module in [`--requestGenerator`](#requestGenerator) below.
+See an example of a request generator module in [`requestGenerator`](doc/api.md#requestGenerator).
 Also see [`sample/request-generator.js`](sample/request-generator.js) for some sample code including a body
 (or [`sample/request-generator.ts`](sample/request-generator.ts) for ES6/TypeScript).
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ but the resulting figure is much more robust.
 Using the provided API it is very easy to integrate loadtest with your package, and run programmatic load tests.
 loadtest makes it very easy to run load tests as part of systems tests, before deploying a new version of your software.
 The result includes mean response times and percentiles,
-so that you can abort deployment e.g. if 99% of the requests don't finish in 10 ms or less.
+so that you can abort deployment e.g. if 99% of all requests don't finish in 10 ms or less.
 
 ### Usage Don'ts
 
@@ -416,7 +416,7 @@ with concurrency 10 (only relevant results are shown):
     Requests per second: 368
     Total time:          44.503181166000005 s
 
-    Percentage of the requests served within a certain time
+    Percentage of requests served within a certain time
       50%      4 ms
       90%      5 ms
       95%      6 ms
@@ -433,7 +433,7 @@ Now we will try a fixed rate of 1000 rps:
     Requests: 9546, requests per second: 1000, mean latency: 0 ms
     Requests: 14549, requests per second: 1000, mean latency: 20 ms
     ...
-    Percentage of the requests served within a certain time
+    Percentage of requests served within a certain time
       50%      1 ms
       90%      2 ms
       95%      8 ms
@@ -464,7 +464,7 @@ Let us lower the rate to 500 rps:
     Requests per second: 488
     Total time:          20.002735398000002 s
 
-    Percentage of the requests served within a certain time
+    Percentage of requests served within a certain time
       50%      1 ms
       90%      1 ms
       95%      1 ms
@@ -487,7 +487,7 @@ The result (with the same test server) is impressive:
     ...
     Requests per second: 4099
 
-    Percentage of the requests served within a certain time
+    Percentage of requests served within a certain time
     50%      2 ms
     90%      3 ms
     95%      3 ms
@@ -500,7 +500,7 @@ Now we're talking! The steady rate also goes up to 2 krps:
     ...
     Requests per second: 1950
 
-    Percentage of the requests served within a certain time
+    Percentage of requests served within a certain time
       50%      1 ms
       90%      2 ms
       95%      2 ms

--- a/README.md
+++ b/README.md
@@ -342,6 +342,15 @@ Sets the certificate for the http client to use. Must be used with `--key`.
 
 Sets the key for the http client to use. Must be used with `--cert`.
 
+#### `--tcp` (experimental)
+
+Option to use low level TCP sockets,
+faster than the standard HTTP library.
+Not all options are supported.
+
+**Warning**: experimental option.
+May not work with your test case.
+
 ### Test Server
 
 loadtest bundles a test server. To run it:

--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -9,9 +9,9 @@ import {getHalfCores} from '../lib/cluster.js'
 
 
 const options = stdio.getopt({
+	maxSeconds: {key: 't', args: 1, description: 'Max time in seconds to wait for responses, default 10'},
 	maxRequests: {key: 'n', args: 1, description: 'Number of requests to perform'},
-	concurrency: {key: 'c', args: 1, description: 'Number of requests to make'},
-	maxSeconds: {key: 't', args: 1, description: 'Max time in seconds to wait for responses'},
+	concurrency: {key: 'c', args: 1, description: 'Number of concurrent requests, default 10'},
 	timeout: {key: 'd', args: 1, description: 'Timeout for each request in milliseconds'},
 	contentType: {key: 'T', args: 1, description: 'MIME type for the body'},
 	cookies: {key: 'C', multiple: true, description: 'Send a cookie as name=value'},

--- a/bin/loadtest.js
+++ b/bin/loadtest.js
@@ -36,7 +36,7 @@ const options = stdio.getopt({
 	cert: {args: 1, description: 'The client certificate to use'},
 	quiet: {description: 'Do not log any messages'},
 	cores: {args: 1, description: 'Number of cores to use', default: getHalfCores()},
-	net: {description: 'Use network sockets (experimental)'},
+	tcp: {description: 'Use TCP sockets (experimental)'},
 	agent: {description: 'Use a keep-alive http agent (deprecated)'},
 	debug: {description: 'Show debug messages (deprecated)'},
 });

--- a/bin/network-performance.js
+++ b/bin/network-performance.js
@@ -1,0 +1,22 @@
+import {loadTest, startServer} from '../index.js'
+
+const port = 7359;
+const serverOptions = {port}
+
+
+async function runNetworkPerformanceTest() {
+	const server = await startServer(serverOptions)
+	const options = {
+		url: `http://localhost:${port}`,
+		method: 'GET',
+		network: true,
+	};
+	const result = await loadTest(options)
+	await server.close()
+	console.log(server)
+	console.log(`Requests received: ${server.totalRequests}`)
+	result.show()
+}
+
+await runNetworkPerformanceTest()
+

--- a/bin/network-performance.js
+++ b/bin/network-performance.js
@@ -13,7 +13,6 @@ async function runNetworkPerformanceTest() {
 	};
 	const result = await loadTest(options)
 	await server.close()
-	console.log(server)
 	console.log(`Requests received: ${server.totalRequests}`)
 	result.show()
 }

--- a/bin/tcp-performance.js
+++ b/bin/tcp-performance.js
@@ -4,12 +4,12 @@ const port = 7359;
 const serverOptions = {port}
 
 
-async function runNetworkPerformanceTest() {
+async function runTcpPerformanceTest() {
 	const server = await startServer(serverOptions)
 	const options = {
 		url: `http://localhost:${port}`,
 		method: 'GET',
-		network: true,
+		tcp: true,
 	};
 	const result = await loadTest(options)
 	await server.close()
@@ -17,5 +17,5 @@ async function runNetworkPerformanceTest() {
 	result.show()
 }
 
-await runNetworkPerformanceTest()
+await runTcpPerformanceTest()
 

--- a/bin/testserver.js
+++ b/bin/testserver.js
@@ -49,7 +49,7 @@ function readOptions() {
 }
 
 function start(options) {
-	runTask(options.cores, async () => await startServer(options))
+	runTask(options.cores, async () => {await startServer(options)})
 }
 
 

--- a/bin/testserver.js
+++ b/bin/testserver.js
@@ -15,7 +15,7 @@ function readOptions() {
 		error: {key: 'e', args: 1, description: 'Return an HTTP error code'},
 		percent: {key: 'p', args: 1, description: 'Return an error (default 500) only for some % of requests'},
 		cores: {key: 'c', args: 1, description: 'Number of cores to use, default is half the total', default: getHalfCores()},
-		body: {key: 'b', args: 1, description: 'Body to return'},
+		body: {key: 'b', args: 1, description: 'Body to return, default "OK"'},
 		file: {key: 'f', args: 1, description: 'File to read and return as body'},
 	});
 	const configuration = loadConfig()

--- a/bin/testserver.js
+++ b/bin/testserver.js
@@ -5,47 +5,47 @@ import {startServer} from '../lib/testserver.js'
 import {loadConfig} from '../lib/config.js'
 import {getHalfCores, runTask} from '../lib/cluster.js'
 
+const configuration = loadConfig()
 const options = readOptions()
 start(options)
 
 
 function readOptions() {
 	const options = stdio.getopt({
+		port: {key: 'p', args: 1, description: 'Port for the server'},
 		delay: {key: 'd', args: 1, description: 'Delay the response for the given milliseconds'},
 		error: {key: 'e', args: 1, description: 'Return an HTTP error code'},
-		percent: {key: 'p', args: 1, description: 'Return an error (default 500) only for some % of requests'},
+		percent: {key: 'P', args: 1, description: 'Return an error (default 500) only for some % of requests'},
 		cores: {key: 'c', args: 1, description: 'Number of cores to use, default is half the total', default: getHalfCores()},
 		body: {key: 'b', args: 1, description: 'Body to return, default "OK"'},
 		file: {key: 'f', args: 1, description: 'File to read and return as body'},
 	});
-	const configuration = loadConfig()
 	if (options.args && options.args.length == 1) {
-		options.port = parseInt(options.args[0], 10);
-		if (!options.port) {
-			console.error('Invalid port');
-			options.printHelp();
-			process.exit(1);
-		}
+		options.port = options.port || options.args[0]
 	}
-	if(options.delay) {
-		if(isNaN(options.delay)) {
-			console.error('Invalid delay');
-			options.printHelp();
-			process.exit(1);
-		}
-		options.delay = parseInt(options.delay, 10);
+	return {
+		port: readInt(options, 'port'),
+		delay: readInt(options, 'delay'),
+		error: readInt(options, 'error'),
+		percent: readInt(options, 'percent'),
+		cores: readInt(options, 'cores'),
+		body: readString(options, 'body'),
+		file: readString(options, 'file'),
 	}
+}
 
-	if(!options.delay) {
-		options.delay = configuration.delay
+function readString(options, key) {
+	return options[key] || configuration[key]
+}
+
+function readInt(options, key) {
+	if (options[key] && isNaN(options[key])) {
+		console.error(`Invalid ${key}`);
+		options.printHelp();
+		process.exit(1);
 	}
-	if(!options.error) {
-		options.error = configuration.error
-	}
-	if(!options.percent) {
-		options.percent = configuration.percent
-	}
-	return options
+	const value = readString(options, key)
+	return parseInt(value) || undefined
 }
 
 function start(options) {

--- a/doc/api.md
+++ b/doc/api.md
@@ -37,7 +37,7 @@ result.show()
 console.log('Tests run successfully')
 ```
 
-The call returns a `Result` object that contains all info about the load test, also described below.
+The call returns a `Result` object that contains all info about the load test, also described [below](#result).
 Call `result.show()` to display the results in the standard format on the console.
 
 As a legacy from before promises existed,
@@ -60,46 +60,6 @@ loadTest(options, function(error, result) {
 	console.log('Tests run successfully')
 })
 ```
-
-
-Beware: if there are no `maxRequests` and no `maxSeconds`, then tests will run forever
-and will not call the callback.
-
-### Result
-
-The latency result returned at the end of the load test contains a full set of data, including:
-mean latency, number of errors and percentiles.
-A simplified example follows:
-
-```javascript
-{
-  url: 'http://localhost:80/',
-  maxRequests: 1000,
-  maxSeconds: 0,
-  concurrency: 10,
-  agent: 'none',
-  requestsPerSecond: undefined,
-  totalRequests: 1000,
-  percentiles: {
-	'50': 7,
-	'90': 10,
-	'95': 11,
-	'99': 15
-  },
-  effectiveRps: 2824,
-  elapsedSeconds: 0.354108,
-  meanLatencyMs: 7.72,
-  maxLatencyMs: 20,
-  totalErrors: 3,
-  errorCodes: {
-	'0': 1,
-	'500': 2
-  },
-}
-```
-
-The `result` object also has a `result.show()` function
-that displays the results on the console in the standard format.
 
 ### Options
 
@@ -327,6 +287,75 @@ especially in local test setups.
 **Warning**: Experimental option.
 May not work for your test case.
 Not compatible with options `indexParam`, `statusCallback`, `requestGenerator`.
+
+### Result
+
+The latency result returned at the end of the load test contains a full set of data, including:
+mean latency, number of errors and percentiles.
+A simplified example follows:
+
+```javascript
+{
+  url: 'http://localhost:80/',
+  maxRequests: 1000,
+  maxSeconds: 0,
+  concurrency: 10,
+  agent: 'none',
+  requestsPerSecond: undefined,
+  totalRequests: 1000,
+  percentiles: {
+	'50': 7,
+	'90': 10,
+	'95': 11,
+	'99': 15
+  },
+  effectiveRps: 2824,
+  elapsedSeconds: 0.354108,
+  meanLatencyMs: 7.72,
+  maxLatencyMs: 20,
+  totalErrors: 3,
+  clients: 10,
+  errorCodes: {
+	'0': 1,
+	'500': 2
+  },
+}
+```
+
+The `result` object also has a `result.show()` function
+that displays the results on the console in the standard format.
+
+Some of the attributes (`url`, `concurrency`) will be identical to the parameters passed.
+The following attributes can also be returned.
+
+#### `totalRequests`
+
+How many requests were actually processed.
+
+#### `totalRequests`
+
+How many requests resulted in an error.
+
+#### `effectiveRps`
+
+How many requests per second were actually processed.
+
+#### `elapsedSeconds`
+
+How many seconds the test lasted.
+
+#### `meanLatencyMs`
+
+Average latency in milliseconds.
+
+#### `errorCodes`
+
+Object containing a map with all status codes received.
+
+#### `clients`
+
+Number of concurrent clients started.
+Should equal the concurrency level unless the `rps` option is specified.
     
 ### Start Test Server
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -287,6 +287,7 @@ especially in local test setups.
 **Warning**: Experimental option.
 May not work for your test case.
 Not compatible with options `indexParam`, `statusCallback`, `requestGenerator`.
+See [TCP Sockets Performance](doc/tcp-sockets.md) for details.
 
 ### Result
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -317,6 +317,16 @@ function contentInspector(result) {
     }
 },
 ```
+
+#### `tcp`
+
+If true, use low-level TCP sockets.
+Faster option that can increase performance by up to 10x,
+especially in local test setups.
+
+**Warning**: Experimental option.
+May not work for your test case.
+Not compatible with options `indexParam`, `statusCallback`, `requestGenerator`.
     
 ### Start Test Server
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -70,23 +70,34 @@ See also the [simplified list](../README.md#loadtest-parameters).
 
 The URL to invoke. Mandatory.
 
-#### `concurrency`
+#### `maxSeconds`
 
-How many clients to start in parallel.
+Max number of seconds to run the tests.
+Default is 10 seconds, applies only if no `maxRequests` is specified.
+
+Note: after the given number of seconds `loadtest` will stop sending requests,
+but may continue receiving tests afterwards.
+
+**Warning**: max seconds used to have no default value,
+so tests would run indefinitely if no `maxSeconds` and no `maxRequests` were specified.
+Max seconds was changed to default to 10 in version 8.
 
 #### `maxRequests`
 
 A max number of requests; after they are reached the test will end.
+Default is no limit;
+will keep on sending until the time limit in `maxSeconds` is reached.
 
 Note: the actual number of requests sent can be bigger if there is a concurrency level;
 loadtest will report just on the max number of requests.
 
-#### `maxSeconds`
+#### `concurrency`
 
-Max number of seconds to run the tests.
+How many clients to start in parallel, default is 10.
+Does not apply if `requestsPerSecond` is specified.
 
-Note: after the given number of seconds `loadtest` will stop sending requests,
-but may continue receiving tests afterwards.
+**Warning**: concurrency used to have a default value of 1,
+until it was changed to 10 in version 8.
 
 #### `timeout`
 
@@ -94,7 +105,7 @@ Timeout for each generated request in milliseconds. Setting this to 0 disables t
 
 #### `cookies`
 
-An array of cookies to send. Each cookie should be a string of the form name=value.
+An array of cookies to send. Each cookie should be a string of the form `name=value`.
 
 #### `headers`
 
@@ -105,9 +116,6 @@ like this:
     {
         accept: "text/plain;text/html"
     }
-
-Note: when using the API, the "host" header is not inferred from the URL but needs to be sent
-explicitly.
 
 #### `method`
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -330,13 +330,16 @@ await server.close()
 ```
 
 This function returns when the server is up and running,
-with an HTTP server which can be `close()`d when it is no longer useful.
+with a server object which can be `close()`d when it is no longer useful.
 As a legacy from before promises existed,
 if an optional callback is passed as second parameter then it will not behave as `async`:
 
 ```javascript
 const server = startServer({port: 8000}, error => console.error(error))
 ```
+
+**Warning**: up until version 7 this function returned an HTTP server;
+this was changed to a test server object with an identical `close()` method.
 
 The following options are available.
 

--- a/doc/network-sockets.md
+++ b/doc/network-sockets.md
@@ -236,7 +236,7 @@ Using this trick we go back to **67 krps**.
 Packets of different lengths are stored for comparison,
 which can cause memory issues when size varies constantly.
 
-## Multiprocess
+### Multiprocess
 
 Now we can go back to using multiple cores:
 
@@ -267,4 +267,25 @@ autocannon http://localhost:7357/ -w 3 -c 30
 Median rate (50% percentile) is **107 krps**.
 So `loadtest` has managed to be slightly above `autocannon`,
 using multiple tricks.
+
+### Pool of Clients
+
+We are not done yet.
+As it happens the new code is not very precise with connections and clients:
+in particular it doesn't play nice with our `--rps` feature,
+which is used to send an exact number of requests per second.
+We need to do a complete refactoring to have a pool of clients,
+take them to fulfill a request and them free them back to the pool.
+
+After the refactoring we get some bad news:
+performance has dropped down back to **60 krps**!
+
+```
+node bin/loadtest.js http://localhost:7357/ --net --cores 1
+[...]
+Effective rps:       60331
+```
+
+We need to do the painstaking exercise of getting back to our target performance.
+
 

--- a/doc/tcp-sockets.md
+++ b/doc/tcp-sockets.md
@@ -1,4 +1,4 @@
-# TCP Sockets
+# TCP Sockets Performance
 
 To improve performance the author tried out using raw TCP sockets
 using the [net module](https://nodejs.org/api/net.html),

--- a/doc/tcp-sockets.md
+++ b/doc/tcp-sockets.md
@@ -1,6 +1,6 @@
-# Network Sockets
+# TCP Sockets
 
-To improve performance the author tried out using raw network sockets
+To improve performance the author tried out using raw TCP sockets
 using the [net module](https://nodejs.org/api/net.html),
 instead of the [HTTP module](https://nodejs.org/api/http.html).
 This is the story of how it went.
@@ -109,7 +109,7 @@ and disregard it.
 The results are almost **80 krps**:
 
 ```
-node bin/loadtest.js http://localhost:7357 --cores 1 --net
+node bin/loadtest.js http://localhost:7357 --cores 1 --tcp
 [...]
 Effective rps:       79997
 ```
@@ -241,7 +241,7 @@ which can cause memory issues when size varies constantly.
 Now we can go back to using multiple cores:
 
 ```
-node bin/loadtest.js http://localhost:7357 --cores 3 --net
+node bin/loadtest.js http://localhost:7357 --cores 3 --tcp
 [...]
 Effective rps:       115379
 ```
@@ -281,7 +281,7 @@ After the refactoring we get some bad news:
 performance has dropped down back to **60 krps**!
 
 ```
-node bin/loadtest.js http://localhost:7357/ --net --cores 1
+node bin/loadtest.js http://localhost:7357/ --tcp --cores 1
 [...]
 Effective rps:       60331
 ```

--- a/doc/tcp-sockets.md
+++ b/doc/tcp-sockets.md
@@ -57,7 +57,7 @@ With keep-alive, 1-core load tester against Nginx:
 |wrk|**111**|
 |loadtest 8.0|61|
 
-Finally, with keep-alive, 3-core load tester against Nginx:
+Finally with keep-alive, 3-core load tester against Nginx:
 
 |package|krps|
 |-------|----|

--- a/doc/tcp-sockets.md
+++ b/doc/tcp-sockets.md
@@ -24,6 +24,7 @@ Detailed explanations follow.
 First without keep-alive, one-core tester against 3-core test server:
 
 |package|krps|
+|-------|----|
 |ab|**20**|
 |loadtest 7.1|6|
 |tcp barebones|10|
@@ -32,6 +33,7 @@ First without keep-alive, one-core tester against 3-core test server:
 Now with keep-alive, also one-core tester against 3-core test server:
 
 |package|krps|
+|-------|----|
 |autocannon|57|
 |wrk|73|
 |loadtest 7.1|20|

--- a/doc/tcp-sockets.md
+++ b/doc/tcp-sockets.md
@@ -36,8 +36,14 @@ so they are not to be compared between them.
 
 #### Apache ab
 
-First target performance is against [Apache `ab`](https://httpd.apache.org/docs/2.4/programs/ab.html),
-with 10 concurrent connections without keep-alive.
+First target performance is against [Apache `ab`](https://httpd.apache.org/docs/2.4/programs/ab.html).
+
+```
+ab -V
+Version 2.3 <$Revision: 1879490 $>
+```
+
+With 10 concurrent connections without keep-alive.
 
 ```
 ab -t 10 -c 10 http://localhost:7357/
@@ -54,6 +60,12 @@ The [autocannon](https://www.npmjs.com/package/autocannon) package uses by defau
 10 concurrent connections with keep-alive enabled:
 
 ```
+autocannon --version
+autocannon v7.12.0
+node v18.17.1
+```
+
+```
 autocannon http://localhost:7357/
 [...]
 ┌───────────┬─────────┬─────────┬─────────┬─────────┬──────────┬─────────┬─────────┐
@@ -65,13 +77,30 @@ autocannon http://localhost:7357/
 └───────────┴─────────┴─────────┴─────────┴─────────┴──────────┴─────────┴─────────┘
 ```
 
-We report the median rate (reported as 50%),
+We will look at the median rate (reported as 50%),
 so results are around **57 krps**.
 Keep-alive cannot be disabled as far as the author knows.
 
+#### `wrk`
+
+To complete the set we try `wrk`:
+
+```
+wrk -v
+wrk debian/4.1.0-3build1 [epoll]
+```
+
+With a single thread (core) for fair comparison we get almost **73 krps**:
+
+```
+wrk http://localhost:7357/ -t 1
+[...]
+Requests/sec:  72639.52
+```
+
 ### Baseline
 
-The baseline is the existing `http` implementation in `loadtest` 7.1,
+The baseline is the existing `http` implementation in `loadtest` 7.1.1,
 running on one core.
 
 Without keep-alive close to **6 krps**:

--- a/doc/tcp-sockets.md
+++ b/doc/tcp-sockets.md
@@ -15,6 +15,30 @@ so it is usually much faster.
 We need to run the measurements with and without it
 to see how each factor is affected.
 
+### Summary
+
+The following tables summarize all comparisons.
+Fastest option is shown **in bold**.
+Detailed explanations follow.
+
+First without keep-alive, one-core tester against 3-core test server:
+
+|package|krps|
+|ab|**20**|
+|loadtest 7.1|6|
+|tcp barebones|10|
+|tcp 8.0|9|
+
+Now with keep-alive, also one-core tester against 3-core test server:
+
+|package|krps|
+|autocannon|57|
+|wrk|73|
+|loadtest 7.1|20|
+|tcp barebones|**80**|
+|tcp 8.0|
+
+
 ## Implementations
 
 All measurements against the test server using 3 cores (default):
@@ -328,6 +352,18 @@ Effective rps:       68466
 ```
 
 Marginally better than before.
+By the way, it would be a good idea to try again without keep-alive.
+There is currently no option to disable keep-alive,
+but it can be done by hacking the header as
+`Keep-alive: close`.
+We get a bit less performance than the barebones implementation,
+almost **9 krps**:
+
+```
+node bin/loadtest.js http://localhost:7357/ --tcp --cores 1
+[...]
+Effective rps:       8682
+```
 
 ### Reproducible Script
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -17,7 +17,7 @@ export async function runTask(cores, task) {
 	if (cluster.isPrimary) {
 		return await runWorkers(cores)
 	} else {
-		const result = await task(cluster.worker.id)
+		const result = await task(cluster.worker.id) || '0'
 		process.send(result)
 	}
 }

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -3,7 +3,6 @@ import * as http from 'http'
 import * as https from 'https'
 import * as querystring from 'querystring'
 import * as websocket from 'websocket'
-import {HighResolutionTimer} from './hrtimer.js'
 import {addUserAgent} from './headers.js'
 import * as agentkeepalive from 'agentkeepalive'
 import * as HttpsProxyAgent from 'https-proxy-agent'
@@ -25,7 +24,7 @@ export class HttpClient {
 		this.loadTest = loadTest
 		this.latency = loadTest.latency
 		this.options = loadTest.options
-		this.stopped = false
+		this.running = true
 		this.init();
 	}
 
@@ -40,18 +39,11 @@ export class HttpClient {
 			this.params.key = this.options.key;
 		}
 		this.params.agent = false;
-		if (this.options.requestsPerSecond) {
-			// rps for each client is total / concurrency (# of clients)
-			this.params.requestsPerSecond = this.options.requestsPerSecond / this.options.concurrency
-		}
 		if (this.options.agentKeepAlive) {
 			const KeepAlive = (this.params.protocol == 'https:') ? agentkeepalive.HttpsAgent : agentkeepalive.default;
 			let maxSockets = 10;
-			if (this.params.requestsPerSecond) {
-				maxSockets += Math.floor(this.params.requestsPerSecond);
-			}
 			this.params.agent = new KeepAlive({
-				maxSockets: maxSockets,
+				maxSockets,
 				maxKeepAliveRequests: 0, // max requests per keepalive socket, default is 0, no limit
 				maxKeepAliveTime: 30000  // keepalive for 30 seconds
 			});
@@ -106,36 +98,32 @@ export class HttpClient {
 	 * Start the HTTP client.
 	 */
 	start() {
-		if (this.stopped) {
-			// solves testing issue: with requestsPerSecond clients are started at random,
-			// so sometimes they are stopped before they have even started
-			return
-		}
-		if (!this.params.requestsPerSecond) {
-			return this.makeRequest();
-		}
-		const interval = 1000 / this.params.requestsPerSecond;
-		this.requestTimer = new HighResolutionTimer(interval, () => this.makeRequest());
+		return this.makeRequest();
 	}
 
 	/**
 	 * Stop the HTTP client.
 	 */
 	stop() {
-		this.stopped = true
-		if (this.requestTimer) {
-			this.requestTimer.stop();
-		}
+		this.running = false
 	}
 
 	/**
 	 * Make a single request to the server.
 	 */
 	makeRequest() {
-		if (!this.loadTest.running) {
-			return;
+		console.log('make 2')
+		if (!this.running) {
+			return
 		}
-		if (this.options.maxRequests && this.latency.startedRequests >= this.options.maxRequests) return
+		if (this.loadTest.checkStop()) {
+			console.log('not running')
+			return
+		}
+		if (this.options.maxRequests && this.latency.startedRequests >= this.options.maxRequests) {
+			console.trace('max')
+			return
+		}
 		this.latency.startedRequests += 1;
 
 		const id = this.latency.start();

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -120,12 +120,10 @@ export class HttpClient {
 			console.log('not running')
 			return
 		}
-		if (this.options.maxRequests && this.latency.startedRequests >= this.options.maxRequests) {
-			console.trace('max')
+		if (!this.latency.shouldSend()) {
+			console.trace('not sending')
 			return
 		}
-		this.latency.startedRequests += 1;
-
 		const id = this.latency.start();
 		const params = {...this.params, headers: {...this.params.headers}}
 		this.customizeIndex(params)

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -112,16 +112,13 @@ export class HttpClient {
 	 * Make a single request to the server.
 	 */
 	makeRequest() {
-		console.log('make 2')
 		if (!this.running) {
 			return
 		}
 		if (this.loadTest.checkStop()) {
-			console.log('not running')
 			return
 		}
 		if (!this.latency.shouldSend()) {
-			console.trace('not sending')
 			return
 		}
 		const id = this.latency.start();

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -121,7 +121,7 @@ export class HttpClient {
 		if (!this.latency.shouldSend()) {
 			return
 		}
-		const id = this.latency.start();
+		const id = this.latency.begin();
 		const params = {...this.params, headers: {...this.params.headers}}
 		this.customizeIndex(params)
 		const request = this.getRequest(id, params)

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -115,9 +115,6 @@ export class HttpClient {
 		if (!this.running) {
 			return
 		}
-		if (this.loadTest.checkStop()) {
-			return
-		}
 		if (!this.latency.shouldSend()) {
 			return
 		}

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -32,6 +32,7 @@ export class Latency {
 	 * Start the request with the given id.
 	 */
 	start(requestId) {
+		this.startedRequests += 1
 		requestId = requestId || randomUUID();
 		this.requests.set(requestId, this.getTimeNs())
 		return requestId;
@@ -63,7 +64,6 @@ export class Latency {
 		this.partialTime += time;
 		this.partialRequests++;
 		this.totalTime += time;
-		this.startedRequests++;
 		if (errorCode) {
 			errorCode = String(errorCode);
 			this.partialErrors++;

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -84,9 +84,7 @@ export class Latency {
 			this.histogramMs[rounded] = 0;
 		}
 		this.histogramMs[rounded] += 1;
-		if (this.shouldStop()) {
-			this.stop();
-		}
+		this.loadTest.checkStop()
 	}
 
 	/**
@@ -142,9 +140,6 @@ export class Latency {
 		return Number(elapsedNs / 1000000n)
 	}
 
-	/**
-	 * Check out if enough requests have been sent out or time has elapsed.
-	 */
 	shouldStop() {
 		if (this.options.maxRequests && this.totalRequests >= this.options.maxRequests) {
 			return true;

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -84,7 +84,6 @@ export class Latency {
 			this.histogramMs[rounded] = 0;
 		}
 		this.histogramMs[rounded] += 1;
-		this.loadTest.checkStop()
 	}
 
 	/**

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -167,8 +167,8 @@ export class Latency {
 	 * Get final result.
 	 */
 	getResult() {
-		const result = new Result(this)
-		result.compute()
+		const result = new Result()
+		result.compute(this)
 		return result
 	}
 

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -171,7 +171,7 @@ export class Latency {
 	getResult() {
 		const result = new Result()
 		result.compute(this)
-		result.clients = this.loadTest.pool.clients.length
+		result.clients = this.loadTest.countClients()
 		return result
 	}
 

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -15,7 +15,7 @@ export class Latency {
 		this.partialRequests = 0;
 		this.partialTime = 0;
 		this.partialErrors = 0;
-		this.startedRequests = 0;
+		this.begunRequests = 0;
 		this.totalRequests = 0
 		this.lastShownNs = this.getTimeNs();
 		this.startTimeNs = this.getTimeNs();
@@ -31,8 +31,8 @@ export class Latency {
 	/**
 	 * Start the request with the given id.
 	 */
-	start(requestId) {
-		this.startedRequests += 1
+	begin(requestId) {
+		this.begunRequests += 1
 		requestId = requestId || randomUUID();
 		this.requests.set(requestId, this.getTimeNs())
 		return requestId;
@@ -135,13 +135,13 @@ export class Latency {
 	 * @return {Number} the elapsed time in milliseconds
 	 */
 	getElapsedMs(startTimeNs) {
-		const endTimeNs = this.getTimeNs()
-		const elapsedNs = endTimeNs - startTimeNs
+		const stopTimeNs = this.getTimeNs()
+		const elapsedNs = stopTimeNs - startTimeNs
 		return Number(elapsedNs / 1000000n)
 	}
 
 	shouldSend() {
-		if (this.options.maxRequests && this.startedRequests >= this.options.maxRequests) {
+		if (this.options.maxRequests && this.begunRequests >= this.options.maxRequests) {
 			return false;
 		}
 		return true
@@ -162,7 +162,7 @@ export class Latency {
 	 * We are finished.
 	 */
 	stop() {
-		this.endTimeNs = this.getTimeNs()
+		this.stopTimeNs = this.getTimeNs()
 	}
 
 	/**

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -169,6 +169,7 @@ export class Latency {
 	getResult() {
 		const result = new Result()
 		result.compute(this)
+		result.clients = this.loadTest.pool.clients.length
 		return result
 	}
 

--- a/lib/latency.js
+++ b/lib/latency.js
@@ -140,6 +140,13 @@ export class Latency {
 		return Number(elapsedNs / 1000000n)
 	}
 
+	shouldSend() {
+		if (this.options.maxRequests && this.startedRequests >= this.options.maxRequests) {
+			return false;
+		}
+		return true
+	}
+
 	shouldStop() {
 		if (this.options.maxRequests && this.totalRequests >= this.options.maxRequests) {
 			return true;

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -98,6 +98,10 @@ class LoadTest {
 		return true
 	}
 
+	countClients() {
+		return this.pool.clients.length
+	}
+
 	/**
 	 * Stop clients.
 	 */

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -87,6 +87,17 @@ class LoadTest {
 		this.pool.start()
 	}
 
+	checkStop() {
+		if (!this.running) {
+			return true
+		}
+		if (!this.latency.shouldStop()) {
+			return false
+		}
+		this.stop()
+		return true
+	}
+
 	/**
 	 * Stop clients.
 	 */

--- a/lib/loadtest.js
+++ b/lib/loadtest.js
@@ -29,6 +29,7 @@ const SHOW_INTERVAL_MS = 5000;
  *	 - debug: show debug messages (deprecated).
  *	 - requestGenerator: use a custom function to generate requests.
  *	 - statusCallback: function called after every request.
+ *	 - tcp: use TCP sockets (experimental).
  * - `callback`: optional `function(result, error)` called if/when the test finishes;
  * if not present a promise is returned.
  */

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -1,7 +1,6 @@
 import * as urlLib from 'url'
 import * as net from 'net'
 import * as querystring from 'querystring'
-import {HighResolutionTimer} from './hrtimer.js'
 import {addUserAgent} from './headers.js'
 import {Parser} from './parser.js'
 
@@ -96,8 +95,6 @@ export class NetworkClient {
 		if (!this.params.requestsPerSecond) {
 			return this.makeRequest();
 		}
-		const interval = 1000 / this.params.requestsPerSecond;
-		this.requestTimer = new HighResolutionTimer(interval, () => this.makeRequest());
 	}
 
 	/**
@@ -105,9 +102,6 @@ export class NetworkClient {
 	 */
 	stop() {
 		this.running = false
-		if (this.requestTimer) {
-			this.requestTimer.stop();
-		}
 		this.connection.end()
 	}
 

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -4,6 +4,10 @@ import * as querystring from 'querystring'
 import {addUserAgent} from './headers.js'
 import {Parser} from './parser.js'
 
+const forbiddenOptions = [
+	'indexParam', 'statusCallback', 'requestGenerator'
+]
+
 
 /**
  * A client for an HTTP connection, using raw sockets. Constructor:
@@ -47,6 +51,11 @@ export class NetworkClient {
 		addUserAgent(this.params.headers);
 		this.params.headers.Connection = 'keep-alive'
 		this.params.request = this.createRequest()
+		for (const option of forbiddenOptions) {
+			if (this.options[option]) {
+				throw new Error(`${option} not supported with network sockets`)
+			}
+		}
 	}
 
 	createRequest() {

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -115,11 +115,8 @@ export class NetworkClient {
 	 * Make a single request to the server.
 	 */
 	makeRequest() {
-		if (!this.loadTest.running) {
+		if (this.loadTest.checkStop()) {
 			return;
-		}
-		if (this.latency.shouldStop()) {
-			return
 		}
 		this.parser = new Parser(this.params.method)
 		const id = this.latency.start();

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -65,11 +65,7 @@ export class NetworkClient {
 		}
 		addUserAgent(this.params.headers);
 		this.params.headers.Connection = 'keep-alive'
-		if (this.options.secureProtocol) {
-			this.params.secureProtocol = this.options.secureProtocol;
-		}
 		this.params.request = this.createRequest()
-		this.connect()
 	}
 
 	createRequest() {
@@ -102,13 +98,16 @@ export class NetworkClient {
 	 */
 	stop() {
 		this.running = false
-		this.connection.end()
+		if (this.connection) {
+			this.connection.end()
+		}
 	}
 
 	/**
 	 * Make a single request to the server.
 	 */
 	makeRequest() {
+		this.connect()
 		if (this.loadTest.checkStop()) {
 			return;
 		}
@@ -119,6 +118,12 @@ export class NetworkClient {
 	}
 
 	connect() {
+		if (!this.running) {
+			return
+		}
+		if (this.connection && !this.connection.destroyed) {
+			return
+		}
 		this.connection = net.connect(this.params.port, this.params.hostname)
 		this.connection.on('data', data => {
 			this.parser.addPacket(data)
@@ -130,10 +135,6 @@ export class NetworkClient {
 			this.finishRequest(`Connection ${this.currentId} failed: ${error}`);
 		});
 		this.connection.on('end', () => {
-			if (!this.running) {
-				return
-			}
-			this.connect()
 		})
 	}
 
@@ -147,6 +148,7 @@ export class NetworkClient {
 	}
 
 	finishRequest(error) {
+		this.connection.end()
 		if (!this.running) {
 			return
 		}

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -119,7 +119,7 @@ export class NetworkClient {
 			return;
 		}
 		this.parser = new Parser(this.params.method)
-		const id = this.latency.start();
+		const id = this.latency.begin();
 		this.currentId = id
 		this.connection.write(this.params.request)
 	}

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -133,8 +133,10 @@ export class NetworkClient {
 		});
 		this.connection.on('error', error => {
 			this.finishRequest(`Connection ${this.currentId} failed: ${error}`);
+			this.connection = null
 		});
 		this.connection.on('end', () => {
+			this.connection = null
 		})
 	}
 

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -99,9 +99,6 @@ export class NetworkClient {
 	 */
 	makeRequest() {
 		this.connect()
-		if (this.loadTest.checkStop()) {
-			return;
-		}
 		this.parser = new Parser(this.params.method)
 		const id = this.latency.begin();
 		this.currentId = id

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -34,10 +34,6 @@ export class NetworkClient {
 			this.params.key = this.options.key;
 		}
 		this.params.agent = false;
-		if (this.options.requestsPerSecond) {
-			// rps for each client is total / concurrency (# of clients)
-			this.params.requestsPerSecond = this.options.requestsPerSecond / this.options.concurrency
-		}
 		this.params.method = this.options.method || 'GET';
 		if (this.options.body) {
 			if (typeof this.options.body == 'string') {
@@ -83,12 +79,7 @@ export class NetworkClient {
 	 * Start the HTTP client.
 	 */
 	start() {
-		if (!this.running) {
-			// solves testing issue: with requestsPerSecond clients are started at random,
-			// so sometimes they are stopped before they have even started
-			return
-		}
-		if (!this.params.requestsPerSecond) {
+		if (!this.options.requestsPerSecond) {
 			return this.makeRequest();
 		}
 	}

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -35,21 +35,6 @@ export class NetworkClient {
 		}
 		this.params.agent = false;
 		this.params.method = this.options.method || 'GET';
-		if (this.options.body) {
-			if (typeof this.options.body == 'string') {
-				this.generateMessage = () => this.options.body;
-			} else if (typeof this.options.body == 'object') {
-				if (this.options.contentType === 'application/x-www-form-urlencoded') {
-					this.options.body = querystring.stringify(this.options.body);
-				}
-				this.generateMessage = () => this.options.body;
-			} else if (typeof this.options.body == 'function') {
-				this.generateMessage = this.options.body;
-			} else {
-				throw new Error(`Unrecognized body: ${typeof this.options.body}`);
-			}
-			this.params.headers['Content-Type'] = this.options.contentType || 'text/plain';
-		}
 		if (this.options.cookies) {
 			if (Array.isArray(this.options.cookies)) {
 				this.params.headers.Cookie =  this.options.cookies.join('; ');
@@ -65,6 +50,9 @@ export class NetworkClient {
 	}
 
 	createRequest() {
+		const body = this.generateBody()
+		this.params.headers['Content-Type'] = this.options.contentType || 'text/plain';
+		this.params.headers['Content-Length'] = Buffer.byteLength(body)
 		const lines = [`${this.params.method} ${this.params.path} HTTP/1.1`]
 		for (const header in this.params.headers) {
 			const value = this.params.headers[header]
@@ -73,6 +61,22 @@ export class NetworkClient {
 		}
 		lines.push(`\r\n`)
 		return lines.join('\r\n')
+	}
+
+	generateBody() {
+		if (!this.options.body) {
+			return ''
+		}
+		if (typeof this.options.body == 'string') {
+			return this.options.body
+		} else if (typeof this.options.body == 'object') {
+			if (this.options.contentType === 'application/x-www-form-urlencoded') {
+				return querystring.stringify(this.options.body);
+			}
+			return JSON.stringify(this.options.body)
+		} else {
+			throw new Error(`Unrecognized body: ${typeof this.options.body}`);
+		}
 	}
 
 	/**
@@ -126,15 +130,6 @@ export class NetworkClient {
 		this.connection.on('end', () => {
 			this.connection = null
 		})
-	}
-
-	getMessage(id) {
-		if (!this.generateMessage) {
-			return
-		}
-		const candidate = this.generateMessage(id);
-		const message = typeof candidate === 'object' ? JSON.stringify(candidate) : candidate
-		return message
 	}
 
 	finishRequest(error) {

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -149,7 +149,10 @@ export class NetworkClient {
 			// not found or not running
 			return;
 		}
-		this.loadTest.pool.finishRequest(this, null, error);
+		if (this.options.maxRequests && this.totalRequests >= this.options.maxRequests) {
+			return;
+		}
+		this.makeRequest()
 	}
 
 	createResult(connection, body) {

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -60,8 +60,10 @@ export class NetworkClient {
 
 	createRequest() {
 		const body = this.generateBody()
-		this.params.headers['Content-Type'] = this.options.contentType || 'text/plain';
-		this.params.headers['Content-Length'] = Buffer.byteLength(body)
+		if (body?.length) {
+			this.params.headers['Content-Type'] = this.options.contentType || 'text/plain';
+			this.params.headers['Content-Length'] = Buffer.byteLength(body)
+		}
 		const lines = [`${this.params.method} ${this.params.path} HTTP/1.1`]
 		for (const header in this.params.headers) {
 			const value = this.params.headers[header]

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -148,7 +148,6 @@ export class NetworkClient {
 	}
 
 	finishRequest(error) {
-		this.connection.end()
 		if (!this.running) {
 			return
 		}

--- a/lib/networkClient.js
+++ b/lib/networkClient.js
@@ -147,6 +147,9 @@ export class NetworkClient {
 	}
 
 	finishRequest(error) {
+		if (!this.running) {
+			return
+		}
 		let errorCode = null;
 		if (this.parser.statusCode >= 400) {
 			errorCode = this.parser.statusCode

--- a/lib/options.js
+++ b/lib/options.js
@@ -46,7 +46,7 @@ class Options {
 		this.proxy = options.proxy || configuration.proxy
 		this.quiet = options.quiet || configuration.quiet
 		this.statusCallback = options.statusCallback
-		this.net = options.net || configuration.net
+		this.tcp = options.tcp || configuration.tcp
 		if (!this.maxRequests && !this.maxSeconds) {
 			this.maxSeconds = 10
 		}

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -33,16 +33,17 @@ export class Pool {
 			return
 		}
 		for (let index = 0; index < this.options.concurrency; index++) {
-			this.addClient();
+			const client = this.addClient();
+			client.start();
 		}
 	}
 
 	addClient() {
 		const client = this.createClient();
 		this.clients.push(client)
-		console.log(`Clients created ${this.clients.length}`)
+		console.log(`Client created ${this.clients.length}`)
 		this.freeClients.push(client)
-		client.start();
+		return client
 	}
 
 	createClient() {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -96,7 +96,7 @@ export class Pool {
 	 */
 	stop() {
 		if (this.requestTimer) {
-			clearTimeout(this.requestTimer);
+			this.requestTimer.stop()
 		}
 		for (const client of this.clients) {
 			client.stop();

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -77,6 +77,11 @@ export class Pool {
 		if (this.loadTest.checkStop()) {
 			return
 		}
+		if (!this.loadTest.latency.shouldSend()) {
+			if (this.requestTimer) {
+				clearTimeout(this.requestTimer);
+			}
+		}
 		if (this.options.statusCallback) {
 			result.requestIndex = this.requestIndex++
 			result.instanceIndex = this.loadTest.instanceIndex

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,5 +1,5 @@
 import {HttpClient} from './httpClient.js'
-import {NetworkClient} from './networkClient.js'
+import {TcpClient} from './tcpClient.js'
 import {WebsocketClient} from './websocket.js'
 import {HighResolutionTimer} from './hrtimer.js'
 
@@ -50,8 +50,8 @@ export class Pool {
 		if (this.options.url.startsWith('ws:')) {
 			return new WebsocketClient(this.loadTest)
 		}
-		if (this.options.net) {
-			return new NetworkClient(this.loadTest)
+		if (this.options.tcp) {
+			return new TcpClient(this.loadTest)
 		}
 		return new HttpClient(this.loadTest);
 	}

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -73,16 +73,19 @@ export class Pool {
 	 * Call after each request has finished.
 	 */
 	finishRequest(client, result, error) {
-		if (this.loadTest.latency.shouldStop()) {
-			this.loadTest.stop();
-		}
-		if (this.loadTest.running && !this.options.requestsPerSecond) {
-			client.makeRequest()
+		console.log(`finish ${this.loadTest.latency.totalRequests}/${this.options.maxRequests}`)
+		if (this.loadTest.checkStop()) {
+			return
 		}
 		if (this.options.statusCallback) {
 			result.requestIndex = this.requestIndex++
 			result.instanceIndex = this.loadTest.instanceIndex
 			this.options.statusCallback(error, result);
+		}
+		if (!this.options.requestsPerSecond) {
+			client.makeRequest()
+		} else {
+			this.freeClients.push(client)
 		}
 	}
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -71,6 +71,11 @@ export class Pool {
 	 * Call after each request has finished.
 	 */
 	finishRequest(client, result, error) {
+		if (this.options.statusCallback) {
+			result.requestIndex = this.requestIndex++
+			result.instanceIndex = this.loadTest.instanceIndex
+			this.options.statusCallback(error, result);
+		}
 		if (this.loadTest.checkStop()) {
 			return
 		}
@@ -78,11 +83,6 @@ export class Pool {
 			if (this.requestTimer) {
 				clearTimeout(this.requestTimer);
 			}
-		}
-		if (this.options.statusCallback) {
-			result.requestIndex = this.requestIndex++
-			result.instanceIndex = this.loadTest.instanceIndex
-			this.options.statusCallback(error, result);
 		}
 		if (!this.options.requestsPerSecond) {
 			client.makeRequest()

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -41,7 +41,6 @@ export class Pool {
 	addClient() {
 		const client = this.createClient();
 		this.clients.push(client)
-		console.log(`Client created ${this.clients.length}`)
 		this.freeClients.push(client)
 		return client
 	}
@@ -61,7 +60,6 @@ export class Pool {
 		if (!this.loadTest.running) {
 			return
 		}
-		console.log('make')
 		if (!this.freeClients.length) {
 			this.addClient()
 		}
@@ -73,7 +71,6 @@ export class Pool {
 	 * Call after each request has finished.
 	 */
 	finishRequest(client, result, error) {
-		console.log(`finish ${this.loadTest.latency.totalRequests}/${this.options.maxRequests}`)
 		if (this.loadTest.checkStop()) {
 			return
 		}

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -81,7 +81,7 @@ export class Pool {
 		}
 		if (!this.loadTest.latency.shouldSend()) {
 			if (this.requestTimer) {
-				clearTimeout(this.requestTimer);
+				this.requestTimer.stop()
 			}
 		}
 		if (!this.options.requestsPerSecond) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -57,6 +57,10 @@ export class Pool {
 	}
 
 	makeRequest() {
+		if (!this.loadTest.running) {
+			return
+		}
+		console.log('make')
 		if (!this.freeClients.length) {
 			this.addClient()
 		}

--- a/lib/result.js
+++ b/lib/result.js
@@ -4,16 +4,7 @@
  * Result of a load test.
  */
 export class Result {
-	constructor(latency) {
-		this.latency = latency
-		const options = latency.options
-		this.url = options.url
-		this.cores = options.cores
-		this.maxRequests = parseInt(options.maxRequests)
-		this.maxSeconds = parseInt(options.maxSeconds)
-		this.concurrency = parseInt(options.concurrency)
-		this.agent = options.agentKeepAlive ? 'keepalive' : 'none';
-		this.requestsPerSecond = parseInt(options.requestsPerSecond)
+	constructor() {
 		this.startTimeMs = Number.MAX_SAFE_INTEGER
 		this.endTimeMs = 0
 		this.elapsedSeconds = 0
@@ -27,16 +18,24 @@ export class Result {
 		this.histogramMs = {}
 	}
 
-	compute() {
-		this.startTimeMs = Number(this.latency.startTimeNs / 1000000n)
-		this.endTimeMs = Number(this.latency.endTimeNs / 1000000n)
-		this.totalRequests = this.latency.totalRequests
-		this.totalErrors = this.latency.totalErrors
-		this.accumulatedMs = this.latency.totalTime
-		this.maxLatencyMs = this.latency.maxLatencyMs
-		this.minLatencyMs = this.latency.minLatencyMs
-		this.errorCodes = this.latency.errorCodes
-		this.histogramMs = this.latency.histogramMs
+	compute(latency) {
+		const options = latency.options
+		this.url = options.url
+		this.cores = options.cores
+		this.maxRequests = parseInt(options.maxRequests)
+		this.maxSeconds = parseInt(options.maxSeconds)
+		this.concurrency = parseInt(options.concurrency)
+		this.agent = options.agentKeepAlive ? 'keepalive' : 'none';
+		this.requestsPerSecond = parseInt(options.requestsPerSecond)
+		this.startTimeMs = Number(latency.startTimeNs / 1000000n)
+		this.endTimeMs = Number(latency.endTimeNs / 1000000n)
+		this.totalRequests = latency.totalRequests
+		this.totalErrors = latency.totalErrors
+		this.accumulatedMs = latency.totalTime
+		this.maxLatencyMs = latency.maxLatencyMs
+		this.minLatencyMs = latency.minLatencyMs
+		this.errorCodes = latency.errorCodes
+		this.histogramMs = latency.histogramMs
 		this.computeDerived()
 	}
 

--- a/lib/result.js
+++ b/lib/result.js
@@ -14,7 +14,7 @@ export class Result {
 		this.requestsPerSecond = null
 		this.clients = 0
 		this.startTimeMs = Number.MAX_SAFE_INTEGER
-		this.endTimeMs = 0
+		this.stopTimeMs = 0
 		this.elapsedSeconds = 0
 		this.totalRequests = 0
 		this.totalErrors = 0
@@ -43,7 +43,7 @@ export class Result {
 		}
 		this.requestsPerSecond = parseInt(options.requestsPerSecond)
 		this.startTimeMs = Number(latency.startTimeNs / 1000000n)
-		this.endTimeMs = Number(latency.endTimeNs / 1000000n)
+		this.stopTimeMs = Number(latency.stopTimeNs / 1000000n)
 		this.totalRequests = latency.totalRequests
 		this.totalErrors = latency.totalErrors
 		this.accumulatedMs = latency.totalTime
@@ -55,7 +55,7 @@ export class Result {
 	}
 
 	computeDerived() {
-		this.elapsedSeconds = (this.endTimeMs - this.startTimeMs) / 1000
+		this.elapsedSeconds = (this.stopTimeMs - this.startTimeMs) / 1000
 		this.totalTimeSeconds = this.elapsedSeconds // backwards compatibility
 		const meanTime = this.accumulatedMs / this.totalRequests
 		this.meanLatencyMs = Math.round(meanTime * 10) / 10
@@ -100,7 +100,7 @@ export class Result {
 		this.clients += result.clients
 		// result
 		this.startTimeMs = Math.min(this.startTimeMs, result.startTimeMs)
-		this.endTimeMs = Math.max(this.endTimeMs, result.endTimeMs)
+		this.stopTimeMs = Math.max(this.stopTimeMs, result.stopTimeMs)
 		this.totalRequests += result.totalRequests
 		this.totalErrors += result.totalErrors
 		this.accumulatedMs += result.accumulatedMs

--- a/lib/result.js
+++ b/lib/result.js
@@ -12,6 +12,7 @@ export class Result {
 		this.concurrency = 0
 		this.agent = null
 		this.requestsPerSecond = null
+		this.clients = 0
 		this.startTimeMs = Number.MAX_SAFE_INTEGER
 		this.endTimeMs = 0
 		this.elapsedSeconds = 0
@@ -32,7 +33,14 @@ export class Result {
 		this.maxRequests = parseInt(options.maxRequests)
 		this.maxSeconds = parseInt(options.maxSeconds)
 		this.concurrency = parseInt(options.concurrency)
-		this.agent = options.agentKeepAlive ? 'keepalive' : 'none';
+		this.clients = latency.clients
+		if (options.net) {
+			this.agent = 'sockets'
+		} else if (options.agentKeepAlive) {
+			this.agent = 'keepalive'
+		} else {
+			this.agent = 'none'
+		}
 		this.requestsPerSecond = parseInt(options.requestsPerSecond)
 		this.startTimeMs = Number(latency.startTimeNs / 1000000n)
 		this.endTimeMs = Number(latency.endTimeNs / 1000000n)
@@ -89,6 +97,7 @@ export class Result {
 		this.concurrency = this.concurrency || result.concurrency
 		this.agent = this.agent || result.agent
 		this.requestsPerSecond += result.requestsPerSecond || 0
+		this.clients += result.clients
 		// result
 		this.startTimeMs = Math.min(this.startTimeMs, result.startTimeMs)
 		this.endTimeMs = Math.max(this.endTimeMs, result.endTimeMs)
@@ -124,14 +133,16 @@ export class Result {
 		} else if (this.maxSeconds) {
 			console.info('Max time (s):        %s', this.maxSeconds);
 		}
-		console.info('Concurrency level:   %s', this.concurrency);
+		if (this.requestsPerSecond) {
+			console.info('Target rps:          %s', this.requestsPerSecond);
+			console.info('Concurrent clients:  %s', this.clients)
+		} else {
+			console.info('Concurrency level:   %s', this.concurrency);
+		}
 		if (this.cores) {
 			console.info('Running on cores:    %s', this.cores);
 		}
 		console.info('Agent:               %s', this.agent);
-		if (this.requestsPerSecond) {
-			console.info('Target rps:          %s', this.requestsPerSecond);
-		}
 		console.info('');
 		console.info('Completed requests:  %s', this.totalRequests);
 		console.info('Total errors:        %s', this.totalErrors);

--- a/lib/result.js
+++ b/lib/result.js
@@ -135,10 +135,8 @@ export class Result {
 		}
 		if (this.requestsPerSecond) {
 			console.info('Target rps:          %s', this.requestsPerSecond);
-			console.info('Concurrent clients:  %s', this.clients)
-		} else {
-			console.info('Concurrency level:   %s', this.concurrency);
 		}
+		console.info('Concurrent clients:  %s', this.clients)
 		if (this.cores) {
 			console.info('Running on cores:    %s', this.cores);
 		}

--- a/lib/result.js
+++ b/lib/result.js
@@ -34,8 +34,8 @@ export class Result {
 		this.maxSeconds = parseInt(options.maxSeconds)
 		this.concurrency = parseInt(options.concurrency)
 		this.clients = latency.clients
-		if (options.net) {
-			this.agent = 'sockets'
+		if (options.tcp) {
+			this.agent = 'tcp'
 		} else if (options.agentKeepAlive) {
 			this.agent = 'keepalive'
 		} else {

--- a/lib/result.js
+++ b/lib/result.js
@@ -148,7 +148,7 @@ export class Result {
 		console.info('Mean latency:        %s ms', this.meanLatencyMs);
 		console.info('Effective rps:       %s', this.effectiveRps);
 		console.info('');
-		console.info('Percentage of the requests served within a certain time');
+		console.info('Percentage of requests served within a certain time');
 
 		Object.keys(this.percentiles).forEach(percentile => {
 			console.info('  %s%      %s ms', percentile, this.percentiles[percentile]);

--- a/lib/result.js
+++ b/lib/result.js
@@ -5,6 +5,13 @@
  */
 export class Result {
 	constructor() {
+		this.url = null
+		this.cores = 0
+		this.maxRequests = 0
+		this.maxSeconds = 0
+		this.concurrency = 0
+		this.agent = null
+		this.requestsPerSecond = null
 		this.startTimeMs = Number.MAX_SAFE_INTEGER
 		this.endTimeMs = 0
 		this.elapsedSeconds = 0

--- a/lib/tcpClient.js
+++ b/lib/tcpClient.js
@@ -71,7 +71,8 @@ export class TcpClient {
 			lines.push(line)
 		}
 		lines.push(`\r\n`)
-		return lines.join('\r\n')
+		const text = lines.join('\r\n')
+		return Buffer.from(text)
 	}
 
 	generateBody() {

--- a/lib/tcpClient.js
+++ b/lib/tcpClient.js
@@ -113,6 +113,9 @@ export class TcpClient {
 	 * Make a single request to the server.
 	 */
 	makeRequest() {
+		if (!this.running) {
+			return
+		}
 		this.connect()
 		this.parser = new Parser(this.params.method)
 		const id = this.latency.begin();
@@ -121,9 +124,6 @@ export class TcpClient {
 	}
 
 	connect() {
-		if (!this.running) {
-			return
-		}
 		if (this.connection && !this.connection.destroyed) {
 			return
 		}

--- a/lib/tcpClient.js
+++ b/lib/tcpClient.js
@@ -10,13 +10,13 @@ const forbiddenOptions = [
 
 
 /**
- * A client for an HTTP connection, using raw sockets. Constructor:
+ * A client for an HTTP connection, using TCP sockets. Constructor:
  *	- `loadTest`: an object with the following attributes:
  *		- `latency`: a variable to measure latency.
  *		- `options`: same options as exports.loadTest.
  *		- `running`: if the loadTest is running or not.
  */
-export class NetworkClient {
+export class TcpClient {
 	constructor(loadTest) {
 		this.loadTest = loadTest
 		this.latency = loadTest.latency
@@ -53,7 +53,7 @@ export class NetworkClient {
 		this.params.request = this.createRequest()
 		for (const option of forbiddenOptions) {
 			if (this.options[option]) {
-				throw new Error(`${option} not supported with network sockets`)
+				throw new Error(`${option} not supported with TCP sockets`)
 			}
 		}
 	}

--- a/lib/tcpClient.js
+++ b/lib/tcpClient.js
@@ -140,16 +140,23 @@ export class TcpClient {
 		});
 		this.connection.on('end', () => {
 			this.connection = null
+			if (this.parser) {
+				// connection waiting for a response; remake
+				this.makeRequest()
+			}
 		})
 	}
 
 	finishRequest(error) {
+		// reset parser for next request
+		const parser = this.parser
+		this.parser = null
 		if (!this.running) {
 			return
 		}
 		let errorCode = null;
-		if (this.parser.statusCode >= 400) {
-			errorCode = this.parser.statusCode
+		if (parser.statusCode >= 400) {
+			errorCode = parser.statusCode
 		}
 		if (error) {
 			// console.error(error)

--- a/lib/tcpClient.js
+++ b/lib/tcpClient.js
@@ -167,8 +167,10 @@ export class TcpClient {
 			// not found or not running
 			return;
 		}
-		if (this.options.maxRequests && this.totalRequests >= this.options.maxRequests) {
+		if (this.options.maxRequests && this.latency.totalRequests >= this.options.maxRequests) {
+			this.loadTest.stop()
 			return;
+
 		}
 		this.makeRequest()
 	}

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -47,6 +47,7 @@ class TestServer {
 		this.wsServer = null;
 		this.latency = new Latency({});
 		this.totalRequests = 0
+		this.partialRequests = 0
 		this.debuggedTime = Date.now();
 		this.body = options.body || 'OK'
 		if (options.file) {
@@ -121,6 +122,7 @@ class TestServer {
 		})
 		request.on('end', () => {
 			request.body = Buffer.concat(bodyBuffers).toString();
+			this.partialRequests += 1
 			this.totalRequests += 1
 			const elapsedMs = Date.now() - this.debuggedTime
 			if (elapsedMs > LOG_HEADERS_INTERVAL_MS) {
@@ -161,7 +163,7 @@ class TestServer {
 		const headers = util.inspect(request.headers)
 		const now = Date.now()
 		const elapsedMs = now - this.debuggedTime
-		const rps = (this.totalRequests / elapsedMs) * 1000
+		const rps = (this.partialRequests / elapsedMs) * 1000
 		if (rps > 1) {
 			console.info(`Requests per second: ${rps.toFixed(0)}`)
 		}
@@ -170,7 +172,7 @@ class TestServer {
 			console.info(`Body: ${request.body}`);
 		}
 		this.debuggedTime = now;
-		this.totalRequests = 0
+		this.partialRequests = 0
 	}
 
 	/**

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -96,7 +96,7 @@ class TestServer {
 				if (!this.options.quiet) console.info('Peer %s disconnected', connection.remoteAddress);
 			});
 		});
-		return this.server
+		return this
 	}
 
 	/**
@@ -205,6 +205,10 @@ class TestServer {
 			return false;
 		}
 		return (Math.random() < percent / 100);
+	}
+
+	close() {
+		this.server.close()
 	}
 }
 

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -60,7 +60,7 @@ class TestServer {
 	 * The callback parameter will be called after the server has started.
 	 */
 	start(callback) {
-		if (this.options.socket) {
+		if (this.options.tcp) {
 			// just for internal debugging
 			this.server = net.createServer(() => this.socketListen());
 		} else {

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -207,8 +207,12 @@ class TestServer {
 		return (Math.random() < percent / 100);
 	}
 
-	close() {
-		this.server.close()
+	close(callback) {
+		if (callback) {
+			this.server.close(callback)
+			return
+		}
+		return this.server.close()
 	}
 }
 

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -109,7 +109,7 @@ class TestServer {
 	 * Listen to an incoming request.
 	 */
 	listen(request, response) {
-		const id = this.latency.start();
+		const id = this.latency.begin();
 		const bodyBuffers = []
 		request.on('data', data => {
 			bodyBuffers.push(data)

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -80,7 +80,7 @@ class TestServer {
 		});
 		this.server.listen(this.port, () => {
 			if (!this.options.quiet) console.info(`Listening on http://localhost:${this.port}/`)
-			callback(null, this.server)
+			callback(null, this)
 		});
 		this.wsServer.on('request', request => {
 			// explicity omitting origin check here.

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -49,7 +49,7 @@ export class WebsocketClient extends BaseClient {
 	 * Make a single request to the server.
 	 */
 	makeRequest() {
-		const id = this.latency.start();
+		const id = this.latency.begin();
 		const requestFinished = this.getRequestFinisher(id);
 
 		if (this.connection.connected) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "loadtest",
-	"version": "7.1.1",
+	"version": "8.0.0",
 	"type": "module",
 	"description": "Run load tests for your web application. Mostly ab-compatible interface, with an option to force requests per second. Includes an API for automated load testing.",
 	"homepage": "https://github.com/alexfernandez/loadtest",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 	},
 	"devDependencies": {
 		"eslint": "^8.47.0",
-		"microprofiler": "^2.0.0"
+		"microprofiler": "^2.0.0",
+		"why-is-node-running": "^2.2.2"
 	},
 	"keywords": [
 		"testing",

--- a/test/all.js
+++ b/test/all.js
@@ -15,6 +15,7 @@ import {test as testLoadtest} from './loadtest.js'
 import {test as testWebsocket} from './websocket.js'
 import {test as integrationTest} from './integration.js'
 import {test as testResult} from './result.js'
+import {test as testNetworkClient} from './networkClient.js'
 
 
 /**
@@ -25,6 +26,7 @@ function test() {
 		testHrtimer, testHeaders, testLatency, testHttpClient,
 		testServer, integrationTest, testLoadtest, testWebsocket,
 		testRequestGenerator, testBodyGenerator, testResult,
+		testNetworkClient,
 	];
 	testing.run(tests, 4200);
 }

--- a/test/all.js
+++ b/test/all.js
@@ -16,6 +16,7 @@ import {test as testWebsocket} from './websocket.js'
 import {test as integrationTest} from './integration.js'
 import {test as testResult} from './result.js'
 import {test as testNetworkClient} from './networkClient.js'
+//import log from 'why-is-node-running'
 
 
 /**
@@ -30,6 +31,8 @@ function test() {
 	];
 	testing.run(tests, 4200);
 }
+
+//setTimeout(log, 4000)
 
 test()
 

--- a/test/all.js
+++ b/test/all.js
@@ -15,7 +15,7 @@ import {test as testLoadtest} from './loadtest.js'
 import {test as testWebsocket} from './websocket.js'
 import {test as integrationTest} from './integration.js'
 import {test as testResult} from './result.js'
-import {test as testNetworkClient} from './networkClient.js'
+import {test as testTcpClient} from './tcpClient.js'
 //import log from 'why-is-node-running'
 
 
@@ -27,7 +27,7 @@ function test() {
 		testHrtimer, testHeaders, testLatency, testHttpClient,
 		testServer, integrationTest, testLoadtest, testWebsocket,
 		testRequestGenerator, testBodyGenerator, testResult,
-		testNetworkClient,
+		testTcpClient,
 	];
 	testing.run(tests, 4200);
 }

--- a/test/body-generator.js
+++ b/test/body-generator.js
@@ -2,16 +2,16 @@ import testing from 'testing'
 import {loadTest} from '../lib/loadtest.js'
 import {startServer} from '../lib/testserver.js'
 
-const PORT = 10453;
+const port = 10453;
 
 
 function testBodyGenerator(callback) {
-	const server = startServer({port: PORT, quiet: true}, error => {
+	const server = startServer({port, quiet: true}, error => {
 		if (error) {
 			return callback('Could not start test server');
 		}
 		const options = {
-			url: 'http://localhost:' + PORT,
+			url: `http://localhost:${port}`,
 			requestsPerSecond: 1000,
 			maxRequests: 100,
 			concurrency: 10,

--- a/test/httpClient.js
+++ b/test/httpClient.js
@@ -4,7 +4,7 @@ import {HttpClient} from '../lib/httpClient.js'
 
 function testHttpClient(callback) {
 	const options = {
-		url: 'http://localhost:7357/',
+		url: 'http://localhost:7358/',
 		maxSeconds: 0.1,
 		concurrency: 1,
 	};

--- a/test/integration.js
+++ b/test/integration.js
@@ -214,7 +214,6 @@ async function testNetworkClient() {
 	const options = {
 		url: 'http://localhost:' + PORT,
 		maxRequests: 100,
-		concurrency: 10,
 		method: 'POST',
 		body: {
 			hi: 'there',
@@ -227,6 +226,22 @@ async function testNetworkClient() {
 	return 'Test result: ' + JSON.stringify(result)
 }
 
+async function testNetworkNoServer() {
+	const options = {
+		url: 'http://localhost:' + PORT,
+		maxRequests: 100,
+		rps: 1000,
+		method: 'POST',
+		body: {
+			hi: 'there',
+		},
+		quiet: true,
+		network: true,
+	};
+	const result = await loadTest(options)
+	return 'Test result: ' + JSON.stringify(result)
+}
+
 /**
  * Run all tests.
  */
@@ -234,6 +249,7 @@ export function test(callback) {
 	testing.run([
 		testIntegration, testIntegrationFile, testDelay, testWSIntegration,
 		testPromise, testIndexParam, testStatusCallback, testNetworkClient,
+		testNetworkNoServer,
 	], 4000, callback);
 }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -3,9 +3,9 @@ import {execFile} from 'child_process'
 import {join} from 'path'
 import {loadTest, startServer} from '../index.js'
 
-const PORT = 10408;
+const port = 10408;
 const serverOptions = {
-	port: PORT,
+	port,
 	quiet: true,
 }
 
@@ -19,7 +19,7 @@ function testIntegration(callback) {
 			return callback(error);
 		}
 		const options = {
-			url: 'http://localhost:' + PORT,
+			url: `http://localhost:${port}`,
 			maxRequests: 100,
 			concurrency: 10,
 			method: 'POST',
@@ -52,7 +52,7 @@ function testIntegrationFile(callback) {
 			return callback(error);
 		}
 		execFile('node',
-			[join('./', 'bin', 'loadtest.js'), `http://localhost:${PORT}/`,
+			[join('./', 'bin', 'loadtest.js'), `http://localhost:${port}/`,
 				'-n', '100', '--quiet'],
 			(error, stdout) => {
 				if (error) {
@@ -79,7 +79,7 @@ function testWSIntegration(callback) {
 			return callback(error);
 		}
 		const options = {
-			url: 'ws://localhost:' + PORT,
+			url: `ws://localhost:${port}`,
 			maxRequests: 10,
 			concurrency: 10,
 			body: {
@@ -113,7 +113,7 @@ function testWSIntegration(callback) {
 function testDelay(callback) {
 	const delay = 10;
 	const serverOptions = {
-		port: PORT + 1,
+		port: port + 1,
 		delay,
 		quiet: true,
 	};
@@ -122,7 +122,7 @@ function testDelay(callback) {
 			return callback(error);
 		}
 		const options = {
-			url: 'http://localhost:' + (PORT + 1),
+			url: 'http://localhost:' + (port + 1),
 			maxRequests: 10,
 			quiet: true,
 		};
@@ -145,7 +145,7 @@ function testDelay(callback) {
 async function testPromise() {
 	const server = await startServer(serverOptions)
 	const options = {
-		url: 'http://localhost:' + PORT,
+		url: `http://localhost:${port}`,
 		maxRequests: 100,
 		concurrency: 10,
 		method: 'POST',
@@ -174,7 +174,7 @@ async function testIndexParam() {
 	}
 	const server = await startServer({logger, ...serverOptions})
 	const options = {
-		url: `http://localhost:${PORT}/?param=index`,
+		url: `http://localhost:${port}/?param=index`,
 		maxRequests: 100,
 		concurrency: 10,
 		postBody: {
@@ -191,7 +191,7 @@ async function testStatusCallback() {
 	let calls = 0
 	const server = await startServer(serverOptions)
 	const options = {
-		url: `http://localhost:${PORT}/`,
+		url: `http://localhost:${port}/`,
 		maxRequests: 100,
 		concurrency: 10,
 		postBody: {
@@ -212,7 +212,7 @@ async function testStatusCallback() {
 async function testNetworkClient() {
 	const server = await startServer(serverOptions)
 	const options = {
-		url: 'http://localhost:' + PORT,
+		url: `http://localhost:${port}`,
 		maxRequests: 100,
 		method: 'POST',
 		body: {
@@ -228,7 +228,7 @@ async function testNetworkClient() {
 
 async function testNetworkNoServer() {
 	const options = {
-		url: 'http://localhost:' + PORT,
+		url: `http://localhost:${port}`,
 		maxRequests: 100,
 		rps: 1000,
 		method: 'POST',

--- a/test/integration.js
+++ b/test/integration.js
@@ -209,13 +209,31 @@ async function testStatusCallback() {
 	await server.close()
 }
 
+async function testNetworkClient() {
+	const server = await startServer(serverOptions)
+	const options = {
+		url: 'http://localhost:' + PORT,
+		maxRequests: 100,
+		concurrency: 10,
+		method: 'POST',
+		body: {
+			hi: 'there',
+		},
+		quiet: true,
+		network: true,
+	};
+	const result = await loadTest(options)
+	await server.close()
+	return 'Test result: ' + JSON.stringify(result)
+}
+
 /**
  * Run all tests.
  */
 export function test(callback) {
 	testing.run([
 		testIntegration, testIntegrationFile, testDelay, testWSIntegration,
-		testPromise, testIndexParam, testStatusCallback,
+		testPromise, testIndexParam, testStatusCallback, testNetworkClient,
 	], 4000, callback);
 }
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -203,7 +203,8 @@ async function testStatusCallback() {
 			calls += 1
 		}
 	};
-	await loadTest(options)
+	const result = await loadTest(options)
+	testing.assertEquals(result.totalRequests, 100, 'Should have 100 requests')
 	testing.assertEquals(calls, 100, 'Should have 100 calls')
 	await server.close()
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -209,7 +209,7 @@ async function testStatusCallback() {
 	await server.close()
 }
 
-async function testNetworkClient() {
+async function testTcpClient() {
 	const server = await startServer(serverOptions)
 	const options = {
 		url: `http://localhost:${port}`,
@@ -219,14 +219,14 @@ async function testNetworkClient() {
 			hi: 'there',
 		},
 		quiet: true,
-		network: true,
+		tcp: true,
 	};
 	const result = await loadTest(options)
 	await server.close()
 	return 'Test result: ' + JSON.stringify(result)
 }
 
-async function testNetworkNoServer() {
+async function testTcpNoServer() {
 	const options = {
 		url: `http://localhost:${port}`,
 		maxRequests: 100,
@@ -236,7 +236,7 @@ async function testNetworkNoServer() {
 			hi: 'there',
 		},
 		quiet: true,
-		network: true,
+		tcp: true,
 	};
 	const result = await loadTest(options)
 	return 'Test result: ' + JSON.stringify(result)
@@ -248,8 +248,8 @@ async function testNetworkNoServer() {
 export function test(callback) {
 	testing.run([
 		testIntegration, testIntegrationFile, testDelay, testWSIntegration,
-		testPromise, testIndexParam, testStatusCallback, testNetworkClient,
-		testNetworkNoServer,
+		testPromise, testIndexParam, testStatusCallback, testTcpClient,
+		testTcpNoServer,
 	], 4000, callback);
 }
 

--- a/test/latency.js
+++ b/test/latency.js
@@ -9,9 +9,9 @@ const mockLoadTest = {running: true, checkStop: () => false, countClients: () =>
  */
 function testLatencyIds(callback) {
 	const latency = new Latency(mockLoadTest);
-	const firstId = latency.start();
+	const firstId = latency.begin();
 	testing.assert(firstId, 'Invalid first latency id %s', firstId, callback);
-	const secondId = latency.start();
+	const secondId = latency.begin();
 	testing.assert(secondId, 'Invalid second latency id', callback);
 	testing.assert(firstId != secondId, 'Repeated latency ids', callback);
 	testing.success(callback);
@@ -27,10 +27,10 @@ function testLatencyRequests(callback) {
 	const errorCode = '500';
 	const latency = new Latency({options, ...mockLoadTest})
 	for (let i = 0; i < 9; i++) {
-		const id = latency.start();
+		const id = latency.begin();
 		latency.end(id);
 	}
-	const id = latency.start();
+	const id = latency.begin();
 	latency.end(id, errorCode);
 	testing.assert(latency.shouldStop(), 'Should stop now', callback);
 	latency.stop()
@@ -52,7 +52,7 @@ function testLatencyPercentiles(callback) {
 	const latency = new Latency({options, ...mockLoadTest})
 	for (let ms = 1; ms <= 10; ms++) {
 		(function() {
-			const id = latency.start();
+			const id = latency.begin();
 			setTimeout(() => {
 				latency.end(id);
 			}, ms);

--- a/test/loadtest.js
+++ b/test/loadtest.js
@@ -4,7 +4,7 @@ import {loadTest} from '../lib/loadtest.js'
 
 function testMaxSeconds(callback) {
 	const options = {
-		url: 'http://localhost:7357/',
+		url: 'http://localhost:7358/',
 		maxSeconds: 0.1,
 		concurrency: 1,
 		quiet: true,
@@ -14,7 +14,7 @@ function testMaxSeconds(callback) {
 
 function testWSEcho(callback) {
 	const options = {
-		url: 'ws://localhost:7357/',
+		url: 'ws://localhost:7358/',
 		maxSeconds: 0.1,
 		concurrency: 1,
 		quiet: true,
@@ -24,7 +24,7 @@ function testWSEcho(callback) {
 
 function testIndexParam(callback) {
 	const options = {
-		url: 'http://localhost:7357/replace',
+		url: 'http://localhost:7358/replace',
 		concurrency:1,
 		maxSeconds: 0.1,
 		indexParam: "replace",
@@ -35,7 +35,7 @@ function testIndexParam(callback) {
 
 function testIndexParamWithBody(callback) {
 	const options = {
-		url: 'http://localhost:7357/replace',
+		url: 'http://localhost:7358/replace',
 		concurrency:1,
 		maxSeconds: 0.1,
 		indexParam: "replace",
@@ -47,7 +47,7 @@ function testIndexParamWithBody(callback) {
 
 function testIndexParamWithCallback(callback) {
 	const options = {
-		url: 'http://localhost:7357/replace',
+		url: 'http://localhost:7358/replace',
 		concurrency:1,
 		maxSeconds: 0.1,
 		indexParam: "replace",
@@ -62,7 +62,7 @@ function testIndexParamWithCallback(callback) {
 
 function testIndexParamWithCallbackAndBody(callback) {
 	const options = {
-		url: 'http://localhost:7357/replace',
+		url: 'http://localhost:7358/replace',
 		concurrency:1,
 		maxSeconds: 0.1,
 		body: '{"id": "replace"}',
@@ -95,7 +95,7 @@ function testError(callback) {
  */
 function testKeepAlive(callback) {
 	const options = {
-		url: 'http://localhost:7357/',
+		url: 'http://localhost:7358/',
 		maxSeconds: 0.1,
 		concurrency: 1,
 		quiet: true,

--- a/test/networkClient.js
+++ b/test/networkClient.js
@@ -8,7 +8,8 @@ function testHttpClient(callback) {
 		maxSeconds: 0.1,
 		concurrency: 1,
 	};
-	new NetworkClient({options});
+	const client = new NetworkClient({options});
+	client.stop()
 	testing.success(callback);
 }
 

--- a/test/networkClient.js
+++ b/test/networkClient.js
@@ -4,7 +4,7 @@ import {NetworkClient} from '../lib/networkClient.js'
 
 function testHttpClient(callback) {
 	const options = {
-		url: 'http://localhost:7357/',
+		url: 'http://localhost:7358/',
 		maxSeconds: 0.1,
 		concurrency: 1,
 	};

--- a/test/networkClient.js
+++ b/test/networkClient.js
@@ -1,0 +1,22 @@
+import testing from 'testing'
+import {NetworkClient} from '../lib/networkClient.js'
+
+
+function testHttpClient(callback) {
+	const options = {
+		url: 'http://localhost:7357/',
+		maxSeconds: 0.1,
+		concurrency: 1,
+	};
+	new NetworkClient({options});
+	testing.success(callback);
+}
+
+
+/**
+ * Run all tests.
+ */
+export function test(callback) {
+	testing.run([testHttpClient], callback)
+}
+

--- a/test/request-generator.js
+++ b/test/request-generator.js
@@ -2,16 +2,16 @@ import testing from 'testing'
 import {loadTest} from '../lib/loadtest.js'
 import {startServer} from '../lib/testserver.js'
 
-const PORT = 10453;
+const port = 10453;
 
 
 function testRequestGenerator(callback) {
-	const server = startServer({port: PORT, quiet: true}, error => {
+	const server = startServer({port, quiet: true}, error => {
 		if (error) {
 			return callback('Could not start test server');
 		}
 		const options = {
-			url: 'http://localhost:' + PORT,
+			url: `http://localhost:${port}`,
 			method: 'POST',
 			requestsPerSecond: 1000,
 			maxRequests: 100,

--- a/test/result.js
+++ b/test/result.js
@@ -23,7 +23,7 @@ function testCombineResults(callback) {
 			totalRequests: 330,
 			totalErrors: 10,
 			startTimeMs: 1000 + index * 1000,
-			endTimeMs: 1000 + index * 2000,
+			stopTimeMs: 1000 + index * 2000,
 			accumulatedMs: 5000,
 			maxLatencyMs: 350 + index,
 			minLatencyMs: 2 + index,

--- a/test/tcpClient.js
+++ b/test/tcpClient.js
@@ -1,5 +1,5 @@
 import testing from 'testing'
-import {NetworkClient} from '../lib/networkClient.js'
+import {TcpClient} from '../lib/tcpClient.js'
 
 
 function testHttpClient(callback) {
@@ -8,7 +8,7 @@ function testHttpClient(callback) {
 		maxSeconds: 0.1,
 		concurrency: 1,
 	};
-	const client = new NetworkClient({options});
+	const client = new TcpClient({options});
 	client.stop()
 	testing.success(callback);
 }

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -4,7 +4,7 @@ import {WebsocketClient} from '../lib/websocket.js'
 
 function testWebsocketClient(callback) {
 	const options = {
-		url: 'ws://localhost:7357/',
+		url: 'ws://localhost:7358/',
 		maxSeconds: 0.1,
 		concurrency: 1,
 	};


### PR DESCRIPTION
Add the new experimental option `--tcp` to use low-level TCP sockets, using the [`net`](https://nodejs.org/api/net.htmlhttps://nodejs.org/api/net.html) library instead of [`http`](https://nodejs.org/api/http.html). Much faster, but some options not implemented. See full write-up in `doc/tcp-sockets.md`.

Also in this PR:

* Add options `--port`, `--body` and `--file` to test server.
* Document `Result` object properly.
* `startServer()` now returns a server object, instead of an HTTP server.
* Create a `Pool` responsible for maintaining the required clients.
* Default timeout of 10 seconds for `loadtest`, instead of running indefinitely.
* Default concurrency of 10 instead of 1.

To be released as v8.0.0.