### PR TITLE
Added guard for undefined result object.

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -71,8 +71,11 @@ export class Pool {
 	 */
 	finishRequest(client, result, error) {
 		if (this.options.statusCallback) {
-			result.requestIndex = this.requestIndex++
-			result.instanceIndex = this.loadTest.instanceIndex
+			// result can be undefined if an error is thrown for a request
+			if (result) {
+				result.requestIndex = this.requestIndex++
+				result.instanceIndex = this.loadTest.instanceIndex
+			}
 			this.options.statusCallback(error, result);
 		}
 		if (this.loadTest.checkStop()) {


### PR DESCRIPTION
This patch is meant to fix the following issue: https://github.com/alexfernandez/loadtest/issues/235

On a HTTP request error, the `finishRequest` method on the `HttpClient` class is called with an undefined `result` object, which eventually gets passed to the request pool. When this happens, the library throws an exception as the `Pool` class tries to set the `requestIndex` attribute on an undefined object.