### PR TITLE
Fix -R requestGenerator file import not working

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -121,7 +121,15 @@ class Options {
 			this.cert = await readFile(this.certFile);
 		}
 		if (this.requestGenerator && typeof this.requestGenerator == 'string') {
-			this.requestGenerator = await import(this.requestGenerator)
+			const requestGeneratorImport = await import(this.requestGenerator)
+			if (typeof requestGeneratorImport === "function") {
+				this.requestGenerator = requestGeneratorImport;
+				return;
+			}
+			if ('default' in requestGeneratorImport && typeof requestGeneratorImport.default === 'function') {
+				this.requestGenerator = requestGeneratorImport.default;
+				return;
+			}
 		}
 		if (this.bodyFile) {
 			this.body = await readBody(this.bodyFile);

--- a/lib/testserver.js
+++ b/lib/testserver.js
@@ -50,6 +50,7 @@ class TestServer {
 		this.partialRequests = 0
 		this.debuggedTime = Date.now();
 		this.body = options.body || 'OK'
+		this.shouldErrorCustom = options.shouldErrorCustom || (() => false);
 		if (options.file) {
 			this.body = readFileSync(options.file)
 		}
@@ -179,7 +180,7 @@ class TestServer {
 	 * End the response now.
 	 */
 	end(request, response, id) {
-		if (this.shouldError()) {
+		if (this.shouldErrorCustom(request) || this.shouldError()) {
 			const code = this.options.error || 500;
 			response.writeHead(code);
 			response.end('ERROR');

--- a/test/fixtures/request-generator.js
+++ b/test/fixtures/request-generator.js
@@ -1,0 +1,9 @@
+export default function requestGenerator(params, options, client, callback) {
+	const message = '{"hi": "ho"}';
+	options.headers['Content-Length'] = message.length;
+	options.headers['Content-Type'] = 'application/json';
+	options.headers['x-test-header'] = 'request-generator-module-import-test';
+	const request = client(options, callback);
+	request.write(message);
+	return request;
+}

--- a/test/request-generator.js
+++ b/test/request-generator.js
@@ -1,7 +1,11 @@
 import testing from 'testing'
 import {loadTest} from '../lib/loadtest.js'
 import {startServer} from '../lib/testserver.js'
+import * as path from 'path'
+import {fileURLToPath} from 'url'
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const port = 10453;
 
 
@@ -54,10 +58,52 @@ function testRequestGenerator(callback) {
 	});
 }
 
+function testRequestGeneratorFromModule(callback) {
+	const server = startServer({port, quiet: true}, error => {
+		if (error) {
+			return callback('Could not start test server');
+		}
+		const requestGeneratorImportPath = path.join(__dirname, 'fixtures', 'request-generator.js');
+		const options = {
+			url: `http://localhost:${port}`,
+			method: 'POST',
+			requestsPerSecond: 1000,
+			maxRequests: 100,
+			concurrency: 10,
+			requestGenerator: requestGeneratorImportPath,
+			quiet: true,
+			shouldErrorCustom: (request) => (
+				request.body !== '{"hi": "ho"}' ||
+				request.headers['content-type'] !== 'application/json' ||
+				request.headers['content-length'] !== request.body.length.toString() ||
+				request.headers['x-test-header'] !== 'request-generator-module-import-test'
+			),
+		};
+		loadTest(options, (error, result) => {
+			if (error) {
+				console.error(error)
+				return callback(`Could not run load test with requestGenerator imported as module: ${error.message}`);
+			}
+			server.close(error => {
+				if (error) {
+					return callback('Could not close test server for request generator module import test');
+				}
+				if (result.totalErrors > 0) {
+					return callback(`There were ${result.totalErrors} errors in the load test`);
+				}
+				return callback(null, 'requestGenerator from module succeeded: ' + JSON.stringify(result));
+			});
+		});
+	});
+}
+
 /**
  * Run all tests.
  */
 export function test(callback) {
-	testing.run([testRequestGenerator], 4000, callback);
+	testing.run([
+		testRequestGenerator,
+		testRequestGeneratorFromModule,
+	], 4000, callback);
 }
 


### PR DESCRIPTION
### Problem
Currently, the -R option does not work for using a custom request generator, because the `await import(request-generator.js)` statement returns an ESM module object containing the `default` property instead of directly returning the function being exported from `request-generator.js`.

### Solution
Start using the `default` property from the imported object as a fallback if the main parent object is not of type `function`.
```
const requestGeneratorImport = await import(this.requestGenerator)
if (typeof requestGeneratorImport === "function") {
  this.requestGenerator = requestGeneratorImport;
  return;
}
if ('default' in requestGeneratorImport && typeof requestGeneratorImport.default === 'function') {
  this.requestGenerator = requestGeneratorImport.default;
  return;
}
```
I have also enhanced the `test/request-generator.js` test file to actually start checking if the custom request generation was successfully done.